### PR TITLE
Update access group endpoint uses PATCH of PUT

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,6 +7,5 @@ GET     /arn/:arn/optin-status              uk.gov.hmrc.agentpermissions.control
 POST    /arn/:arn/group/create              uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.createGroup(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
 GET     /arn/:arn/groups-information        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.groupsSummaries(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
 GET     /gid/:gid/group                     uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.getGroup(gid: String)
-PUT     /gid/:gid/group-name                uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.renameGroup(gid: String)
 DELETE  /group/gid/:gid                     uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.deleteGroup(gid: String)
-PUT     /gid/:gid/update                    uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.updateGroup(gid: String)
+PATCH   /groups/:gid                        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.updateGroup(gid: String)

--- a/test/uk/gov/hmrc/agentpermissions/controllers/UpdateAccessGroupRequestSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/UpdateAccessGroupRequestSpec.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.controllers
+
+import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, AgentUser, Arn, Enrolment, Identifier}
+import uk.gov.hmrc.agentpermissions.BaseSpec
+
+import java.time.LocalDateTime
+
+class UpdateAccessGroupRequestSpec extends BaseSpec {
+
+  val arn: Arn = Arn("KARN0762398")
+  val user: AgentUser = AgentUser("userId", "userName")
+  val groupName = "some existing group name"
+  lazy val now: LocalDateTime = LocalDateTime.now()
+  val user1: AgentUser = AgentUser("user1", "User 1")
+  val user2: AgentUser = AgentUser("user2", "User 2")
+  val enrolment1: Enrolment =
+    Enrolment("HMRC-MTD-VAT", "Activated", "John Innes", Seq(Identifier("VRN", "101747641")))
+  val enrolment2: Enrolment =
+    Enrolment("HMRC-PPT-ORG", "Activated", "Frank Wright", Seq(Identifier("EtmpRegistrationNumber", "XAPPT0000012345")))
+  val groupNameToUpdate = "name to update"
+  val teamMembersToUpdate: Set[AgentUser] = Set(user1, user2)
+  val clientsToUpdate: Set[Enrolment] = Set(enrolment1, enrolment2)
+  val accessGroup: AccessGroup = AccessGroup(arn, groupName, now, now, user, user, Some(Set.empty), Some(Set.empty))
+
+  "Merge" when {
+
+    "access group is not existing" should {
+      "return nothing" in {
+        val maybeExistingAccessGroup: Option[AccessGroup] = None
+
+        val maybeGroupNameToUpdate: Option[String] = Some(groupNameToUpdate)
+        val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = Some(teamMembersToUpdate)
+        val maybeClientsToUpdate: Option[Set[Enrolment]] = Some(clientsToUpdate)
+
+        val updateAccessGroupRequest =
+          UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+        updateAccessGroupRequest.merge(maybeExistingAccessGroup) shouldBe None
+      }
+    }
+
+    "access group exists" when {
+
+      "request has nothing to update" should {
+        "return existing access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = None
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = None
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = None
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup) shouldBe maybeExistingAccessGroup
+        }
+      }
+
+      "request has only group name to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = Some(groupNameToUpdate)
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = None
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = None
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe accessGroup.copy(groupName =
+            groupNameToUpdate
+          )
+        }
+      }
+
+      "request has only team members to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = None
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = Some(teamMembersToUpdate)
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = None
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe accessGroup.copy(teamMembers =
+            Some(teamMembersToUpdate)
+          )
+        }
+      }
+
+      "request has only clients to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = None
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = None
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = Some(clientsToUpdate)
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe accessGroup.copy(clients =
+            Some(clientsToUpdate)
+          )
+        }
+      }
+
+      "request has group name and team members to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = Some(groupNameToUpdate)
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = Some(teamMembersToUpdate)
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = None
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe
+            accessGroup.copy(groupName = groupNameToUpdate, teamMembers = Some(teamMembersToUpdate))
+        }
+      }
+
+      "request has group name and clients to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = Some(groupNameToUpdate)
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = None
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = Some(clientsToUpdate)
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe
+            accessGroup.copy(groupName = groupNameToUpdate, clients = Some(clientsToUpdate))
+        }
+      }
+
+      "request has team members and clients to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = None
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = Some(teamMembersToUpdate)
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = Some(clientsToUpdate)
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe
+            accessGroup.copy(teamMembers = Some(teamMembersToUpdate), clients = Some(clientsToUpdate))
+        }
+      }
+
+      "request has group name, team members and clients to update" should {
+        "return merged access group" in {
+          val maybeExistingAccessGroup: Option[AccessGroup] = Some(accessGroup)
+
+          val maybeGroupNameToUpdate: Option[String] = Some(groupNameToUpdate)
+          val maybeTeamMembersToUpdate: Option[Set[AgentUser]] = Some(teamMembersToUpdate)
+          val maybeClientsToUpdate: Option[Set[Enrolment]] = Some(clientsToUpdate)
+
+          val updateAccessGroupRequest =
+            UpdateAccessGroupRequest(maybeGroupNameToUpdate, maybeTeamMembersToUpdate, maybeClientsToUpdate)
+
+          updateAccessGroupRequest.merge(maybeExistingAccessGroup).get shouldBe
+            accessGroup.copy(
+              groupName = groupNameToUpdate,
+              teamMembers = Some(teamMembersToUpdate),
+              clients = Some(clientsToUpdate)
+            )
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepositorySpec.scala
@@ -35,7 +35,6 @@ class AccessGroupsRepositorySpec extends BaseSpec with DefaultPlayMongoRepositor
     val agent: AgentUser = AgentUser("userId", "userName")
     val user1: AgentUser = AgentUser("user1", "User 1")
     val user2: AgentUser = AgentUser("user2", "User 2")
-    val renamedGroupName = "renamedGroupName"
 
     val enrolment1: Enrolment =
       Enrolment("HMRC-MTD-VAT", "Activated", "John Innes", Seq(Identifier("VRN", "101747641")))
@@ -129,19 +128,6 @@ class AccessGroupsRepositorySpec extends BaseSpec with DefaultPlayMongoRepositor
             accessGroup.copy(groupName = accessGroup.groupName.toUpperCase)
 
           accessGroupsRepository.insert(accessGroupHavingGroupNameOfDifferentCase).futureValue shouldBe None
-        }
-      }
-    }
-
-    "renaming group" when {
-
-      "group name provided is different than that existing in DB" should {
-        s"return $RecordUpdated" in new TestScope {
-          accessGroupsRepository.insert(accessGroup).futureValue.get shouldBe a[String]
-
-          accessGroupsRepository.renameGroup(arn, groupName, renamedGroupName, agent).futureValue shouldBe Some(
-            RecordUpdated
-          )
         }
       }
     }


### PR DESCRIPTION
- The 'update access group' endpoint now uses a PATCH endpoint instead of a PUT.
- The PATCH payload can contain these optional fields: _groupName_, _teamMembers_, and _clients_
- Removes 'rename group' endpoint, as that functionality covered in the PATCH

An example PATCH payload looks like:
```
{
  "groupName": "Glastonbury",
  "teamMembers": [
    {
      "id": "abcA01",
      "name": "Mila Ling"
    },
    ...
  ],
  "clients": [
    {
      "service": "HMRC-PPT-ORG",
      "state": "Activated",
      "friendlyName": "Frank Wright",
      "identifiers": [
        {
          "key": "EtmpRegistrationNumber",
          "value": "XAPPT0000012345"
        }
      ]
    },
    ...
  ]
}
```