### PR TITLE
Updates URIs for AccessGroup CRUD endpoints

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,8 +4,8 @@ POST    /arn/:arn/optin                     uk.gov.hmrc.agentpermissions.control
 POST    /arn/:arn/optout                    uk.gov.hmrc.agentpermissions.controllers.OptinController.optout(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
 GET     /arn/:arn/optin-status              uk.gov.hmrc.agentpermissions.controllers.OptinController.optinStatus(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
 
-POST    /arn/:arn/group/create              uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.createGroup(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
-GET     /arn/:arn/groups-information        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.groupsSummaries(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
-GET     /gid/:gid/group                     uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.getGroup(gid: String)
-DELETE  /group/gid/:gid                     uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.deleteGroup(gid: String)
+POST    /arn/:arn/groups                    uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.createGroup(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
+GET     /arn/:arn/groups                    uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.groupsSummaries(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
+GET     /groups/:gid                        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.getGroup(gid: String)
+DELETE  /groups/:gid                        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.deleteGroup(gid: String)
 PATCH   /groups/:gid                        uk.gov.hmrc.agentpermissions.controllers.AccessGroupsController.updateGroup(gid: String)


### PR DESCRIPTION

- Create access group: `POST /arn/:arn/groups`
- Fetch all group summaries: `GET /arn/:arn/groups`
- Fetch a group: `GET /groups/:gid`
- Delete a group: `DELETE /groups/:gid`
- Update a group: `PATCH /groups/:gid`