### PR TITLE
Chunks large payload when pushing assigns/unassigns

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentsSplitter.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentsSplitter.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.service.userenrolment
+
+import uk.gov.hmrc.agentmtdidentifiers.model.{UserEnrolment, UserEnrolmentAssignments}
+
+object UserEnrolmentAssignmentsSplitter {
+
+  def split(
+    userEnrolmentAssignments: UserEnrolmentAssignments,
+    chunkSize: Int = 1000
+  ): Seq[UserEnrolmentAssignments] = {
+    val assignsChunks = userEnrolmentAssignments.assign
+      .grouped(chunkSize)
+      .map(assignsChunk =>
+        UserEnrolmentAssignments(
+          assign = assignsChunk,
+          unassign = Set.empty[UserEnrolment],
+          arn = userEnrolmentAssignments.arn
+        )
+      )
+      .toSeq
+
+    val unassignsChunks = userEnrolmentAssignments.unassign
+      .grouped(chunkSize)
+      .map(unassignsChunk =>
+        UserEnrolmentAssignments(
+          assign = Set.empty[UserEnrolment],
+          unassign = unassignsChunk,
+          arn = userEnrolmentAssignments.arn
+        )
+      )
+      .toSeq
+
+    assignsChunks ++ unassignsChunks
+  }
+
+}

--- a/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
@@ -63,11 +63,11 @@ class AccessGroupsServiceSpec extends BaseSpec {
 
         "assignments get pushed" should {
           s"return $AccessGroupCreated" in new TestScope {
-            mockUserEnrolmentAssignmentServiceCalculateForCreatingGroup(maybeUserEnrolmentAssignments)
             mockAccessGroupsRepositoryGet(None)
+            mockUserEnrolmentAssignmentServiceCalculateForCreatingGroup(maybeUserEnrolmentAssignments)
             mockAccessGroupsRepositoryInsert(accessGroupInMongo, Some(insertedId))
             mockUserEnrolmentAssignmentServicePushCalculatedAssignments(AssignmentsPushed)
-            mockAuditConnectorSendExplicitAudit("GranularPermissionsES11AssignmentsUnassignmentsPushed")
+            mockAuditConnectorSendExplicitAudit("GranularPermissionsESAssignmentsUnassignmentsPushed")
             mockAuditConnectorSendExplicitAudit("GranularPermissionsAccessGroupCreated")
 
             accessGroupsService
@@ -226,7 +226,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
               mockUserEnrolmentAssignmentServiceCalculateForDeletingGroup(maybeUserEnrolmentAssignments)
               mockAccessGroupsRepositoryDelete(Some(1L))
               mockUserEnrolmentAssignmentServicePushCalculatedAssignments(AssignmentsPushed)
-              mockAuditConnectorSendExplicitAudit("GranularPermissionsES11AssignmentsUnassignmentsPushed")
+              mockAuditConnectorSendExplicitAudit("GranularPermissionsESAssignmentsUnassignmentsPushed")
               mockAuditConnectorSendExplicitAudit("GranularPermissionsAccessGroupDeleted")
 
               accessGroupsService.delete(groupId, user).futureValue shouldBe AccessGroupDeleted
@@ -275,7 +275,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
             mockUserEnrolmentAssignmentServiceCalculateForUpdatingGroup(maybeUserEnrolmentAssignments)
             mockAccessGroupsRepositoryUpdate(Some(1))
             mockUserEnrolmentAssignmentServicePushCalculatedAssignments(AssignmentsPushed)
-            mockAuditConnectorSendExplicitAudit("GranularPermissionsES11AssignmentsUnassignmentsPushed")
+            mockAuditConnectorSendExplicitAudit("GranularPermissionsESAssignmentsUnassignmentsPushed")
             mockAuditConnectorSendExplicitAudit("GranularPermissionsAccessGroupUpdated")
 
             accessGroupsService.update(groupId, accessGroup, user).futureValue shouldBe AccessGroupUpdated
@@ -491,7 +491,11 @@ class AccessGroupsServiceSpec extends BaseSpec {
         mockAuditConnector
       )
 
-    val userEnrolmentAssignments: UserEnrolmentAssignments = UserEnrolmentAssignments(Set.empty, Set.empty, arn)
+    val userEnrolmentAssignments: UserEnrolmentAssignments = UserEnrolmentAssignments(
+      assign = Set(UserEnrolment(user.id, clientVat.enrolmentKey)),
+      unassign = Set.empty,
+      arn = arn
+    )
     val maybeUserEnrolmentAssignments: Option[UserEnrolmentAssignments] = Some(userEnrolmentAssignments)
 
     lazy val now: LocalDateTime = LocalDateTime.now()

--- a/test/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentServiceSpec.scala
@@ -99,6 +99,7 @@ class UserEnrolmentAssignmentServiceSpec extends BaseSpec {
       (mockUserClientDetailsConnector
         .pushAssignments(_: UserEnrolmentAssignments)(_: HeaderCarrier, _: ExecutionContext))
         .expects(userEnrolmentAssignments, *, *)
+        .anyNumberOfTimes()
         .returning(Future successful pushStatus)
   }
 

--- a/test/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentsSplitterSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentsSplitterSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.service.userenrolment
+
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, UserEnrolment, UserEnrolmentAssignments}
+import uk.gov.hmrc.agentpermissions.BaseSpec
+
+import scala.util.Random
+
+class UserEnrolmentAssignmentsSplitterSpec extends BaseSpec {
+
+  val arn: Arn = Arn("KARN1234567")
+
+  "Splitter" when {
+
+    "both assigns and unassigns are empty" should {
+      "return empty list" in {
+        UserEnrolmentAssignmentsSplitter.split(UserEnrolmentAssignments(Set.empty, Set.empty, arn)) shouldBe Seq.empty
+      }
+    }
+
+    "assigns and unassigns are non-empty" should {
+      "split with correct count" in {
+        val maxIndex = 100
+        val chunkSize = 10
+
+        val assigns = buildRandomUserEnrolments(maxIndex)
+        val unassigns = buildRandomUserEnrolments(maxIndex)
+
+        val splitUserEnrolmentAssignments =
+          UserEnrolmentAssignmentsSplitter.split(UserEnrolmentAssignments(assigns, unassigns, arn), chunkSize)
+
+        (roundUp((assigns.size.toDouble) / chunkSize) + roundUp(
+          (unassigns.size.toDouble) / chunkSize
+        )) shouldBe splitUserEnrolmentAssignments.size
+      }
+    }
+  }
+
+  def buildRandomUserEnrolments(maxIndex: Int): Set[UserEnrolment] = {
+    val r = new Random
+
+    for {
+      indexTeamMember: Int <- (1 to r.nextInt(maxIndex)).toSet
+      indexClient: Int     <- (1 to r.nextInt(maxIndex)).toSet
+    } yield UserEnrolment(s"user$indexTeamMember", s"enrolmentKey$indexClient")
+  }
+
+  def roundUp(d: Double): Int = math.ceil(d).toInt
+
+}


### PR DESCRIPTION
Splits large set of ES Proxy assignments/unassignments into smaller sets for:
- posting via AUCD
- audit events 