### PR TITLE
 [CS] update for new access group summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 
 Backend service to store opt-in status and any agent-permissions-specific structures, such as groups.
 
+Custom access groups, or just access groups are created via User level assignments in EACD.
+
+Tax service access groups only exist within Agent Services as an allowlist of team members for a particular enrolment type. Only those currently supported by Agent Services Account are included. Income Record Viewer is not supported. Trusts are handled as one entity (taxable and non-taxable grouped together).
+
+**Enrolments for tax service groups**
+- HMRC-MTD-VAT
+- HMRC-MTD-IT
+- HMRC-TERS-ORG and HMRC-TERSNT-ORG (Trusts)
+- HMRC-CGT-PD
+- HMRC-PPT-ORG
+
+Even though custom access groups and tax service groups are separate, they cannot share the same name
+
 ## Endpoints
 
 ### Opt in/out
@@ -14,15 +27,30 @@ Backend service to store opt-in status and any agent-permissions-specific struct
 | POST  | /arn/:arn/optout           | Opt-out an agent from using agent permissions feature  | false |
 | GET  | /arn/:arn/optin-record-exists           | Returns 204 if the ARN has opted-in otherwise returns 404  | true |
 
-### Create or Manage access group
+### Group checks
 | **Method** | **Path**                       | **Description**                           |Allows Assistant user|
 |------------|--------------------------------|-------------------------------------------|----|
 | GET   | /arn/:arn/access-group-name-check?name=:encodedName      |    Checks if group name has already been used. Returns OK or CONFLICT  | false |
-| POST  | /arn/:arn/groups             | Creates an access group. Returns CREATED          | false |
-| GET   |  /arn/:arn/groups            | Gets summary of groups and unassigned clients     | true |
-| GET   | /groups/:groupId            |  Gets access group based on groupId                | true |
-| PATCH | /groups/:groupId             |  Updates a group (name, clients, team members) from their groupId             | false |
-| DELETE | /groups/:groupId             |  Deletes a group from their groupId             | false |
+| GET   | /arn/:arn/all-groups      | NOT IMPLEMENTED - Gets summaries of custom groups & tax service groups   | true |
+
+### Create & Manage custom access groups
+| **Method** | **Path**          | **Description**                           |Allows Assistant user|
+|------------|-------------------|-------------------------------------------|----|
+| POST   | /arn/:arn/groups      | Creates a custom access group. Returns CREATED          | false |
+| GET    | /arn/:arn/groups      | Gets summaries of custom groups ONLY   | true |
+| GET    | /groups/:groupId      | Gets custom access group based on groupId                | true |
+| PATCH  | /groups/:groupId      | Updates a group (name, clients, team members) from their groupId             | false |
+| DELETE | /groups/:groupId      | Deletes a group from their groupId             | false |
+
+### Create & Manage tax service groups (not yet implemented)
+| **Method** | **Path**          | **Description**                           |Allows Assistant user|
+|------------|-------------------|-------------------------------------------|----|
+| POST   | /arn/:arn/tax-group   | NOT IMPLEMENTED - Creates a tax service group. Returns CREATED          | false |
+| GET    | /arn/:arn/tax-groups  | NOT IMPLEMENTED - Gets summaries of tax service groups ONLY            | true |
+| GET    | /tax-group/:groupId   | NOT IMPLEMENTED - Gets tax service group based on groupId        | true |
+| GET    | /arn/:arn/tax-group/:service  | NOT IMPLEMENTED - Gets tax service group for ARN based on service             | true |
+| PATCH  | /tax-group/:groupId   | NOT IMPLEMENTED - Updates a group (name, team members, excluded clients, auto-updates) from their groupId             | false |
+| DELETE | /tax-group/:groupId   | NOT IMPLEMENTED - Deletes a group from their groupId             | false |
 
 ### Manage clients/team members
 | **Method** | **Path**                       | **Description**                           |Allows Assistant user|

--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -85,7 +85,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
       withValidAndMatchingArn(arn, authorisedAgent) { _ =>
         accessGroupsService
           .getAllGroups(arn)
-          .map(groups => Ok(Json.toJson(groups.map(AccessGroupSummary.convert))))
+          .map(groups => Ok(Json.toJson(groups.map(AccessGroupSummary.convertCustomGroup))))
       }
     } transformWith failureHandler
   }
@@ -281,4 +281,3 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
       Future.successful(InternalServerError)
   }
 }
-

--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.agentpermissions.controllers
 import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.agentmtdidentifiers.model._
+import uk.gov.hmrc.agentpermissions.model.{AddMembersToAccessGroupRequest, CreateAccessGroupRequest, UpdateAccessGroupRequest}
 import uk.gov.hmrc.agentpermissions.service._
 import uk.gov.hmrc.auth.core.AuthorisationException
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import java.time.LocalDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -79,6 +79,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
     } transformWith failureHandler
   }
 
+  // gets access group summaries for custom groups ONLY
   def groups(arn: Arn): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAgent(allowStandardUser = true) { authorisedAgent =>
       withValidAndMatchingArn(arn, authorisedAgent) { _ =>
@@ -89,6 +90,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
     } transformWith failureHandler
   }
 
+  // gets a custom access group ONLY
   def getGroup(gid: String): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAgent(allowStandardUser = true) { authorisedAgent =>
       accessGroupsService.getById(gid) map {
@@ -105,6 +107,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
     } transformWith failureHandler
   }
 
+  // gets custom group summaries for client TODO include tax service groups
   def getGroupSummariesForClient(arn: Arn, enrolmentKey: String): Action[AnyContent] = Action.async {
     implicit request =>
       withAuthorisedAgent() { _ =>
@@ -114,6 +117,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
       } transformWith failureHandler
   }
 
+  // gets custom group summaries for team member TODO include tax service groups
   def getGroupSummariesForTeamMember(arn: Arn, userId: String): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAgent(allowStandardUser = true) { _ =>
       accessGroupsService
@@ -191,6 +195,7 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
     } transformWith failureHandler
   }
 
+  // checks custom access groups names TODO include tax service groups
   def groupNameCheck(arn: Arn, name: String): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAgent() { authorisedAgent =>
       withValidAndMatchingArn(arn, authorisedAgent) { matchedArn =>
@@ -277,55 +282,3 @@ class AccessGroupsController @Inject() (accessGroupsService: AccessGroupsService
   }
 }
 
-case class CreateAccessGroupRequest(
-  groupName: String,
-  teamMembers: Option[Set[AgentUser]],
-  clients: Option[Set[Client]]
-) {
-  def buildAccessGroup(
-    arn: Arn,
-    agentUser: AgentUser
-  ): AccessGroup = {
-    val now = LocalDateTime.now()
-
-    AccessGroup(
-      arn,
-      Option(groupName).map(_.trim).getOrElse(""),
-      now,
-      now,
-      agentUser,
-      agentUser,
-      teamMembers,
-      clients
-    )
-  }
-}
-
-object CreateAccessGroupRequest {
-  implicit val formatCreateAccessGroupRequest: OFormat[CreateAccessGroupRequest] = Json.format[CreateAccessGroupRequest]
-}
-
-case class UpdateAccessGroupRequest(
-  groupName: Option[String],
-  teamMembers: Option[Set[AgentUser]],
-  clients: Option[Set[Client]]
-) {
-
-  def merge(existingAccessGroup: AccessGroup): AccessGroup = {
-    val withMergedGroupName = groupName.fold(existingAccessGroup)(name =>
-      existingAccessGroup.copy(groupName = Option(name).map(_.trim).getOrElse(""))
-    )
-    val withMergedClients = clients.fold(withMergedGroupName)(cls => withMergedGroupName.copy(clients = Some(cls)))
-    teamMembers.fold(withMergedClients)(members => withMergedClients.copy(teamMembers = Some(members)))
-  }
-}
-
-object UpdateAccessGroupRequest {
-  implicit val format: OFormat[UpdateAccessGroupRequest] = Json.format[UpdateAccessGroupRequest]
-}
-
-case class AddMembersToAccessGroupRequest(teamMembers: Option[Set[AgentUser]], clients: Option[Set[Client]])
-
-object AddMembersToAccessGroupRequest {
-  implicit val format: OFormat[AddMembersToAccessGroupRequest] = Json.format[AddMembersToAccessGroupRequest]
-}

--- a/app/uk/gov/hmrc/agentpermissions/model/CustomAccessGroupRequests.scala
+++ b/app/uk/gov/hmrc/agentpermissions/model/CustomAccessGroupRequests.scala
@@ -1,0 +1,59 @@
+package uk.gov.hmrc.agentpermissions.model
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, AgentUser, Arn, Client}
+
+import java.time.LocalDateTime
+
+case class CreateAccessGroupRequest(
+                                     groupName: String,
+                                     teamMembers: Option[Set[AgentUser]],
+                                     clients: Option[Set[Client]]
+                                   ) {
+  def buildAccessGroup(
+                        arn: Arn,
+                        agentUser: AgentUser
+                      ): AccessGroup = {
+    val now = LocalDateTime.now()
+
+    AccessGroup(
+      arn,
+      Option(groupName).map(_.trim).getOrElse(""),
+      now,
+      now,
+      agentUser,
+      agentUser,
+      teamMembers,
+      clients
+    )
+  }
+}
+
+object CreateAccessGroupRequest {
+  implicit val formatCreateAccessGroupRequest: OFormat[CreateAccessGroupRequest] = Json.format[CreateAccessGroupRequest]
+}
+
+case class UpdateAccessGroupRequest(
+                                     groupName: Option[String],
+                                     teamMembers: Option[Set[AgentUser]],
+                                     clients: Option[Set[Client]]
+                                   ) {
+
+  def merge(existingAccessGroup: AccessGroup): AccessGroup = {
+    val withMergedGroupName = groupName.fold(existingAccessGroup)(name =>
+      existingAccessGroup.copy(groupName = Option(name).map(_.trim).getOrElse(""))
+    )
+    val withMergedClients = clients.fold(withMergedGroupName)(cls => withMergedGroupName.copy(clients = Some(cls)))
+    teamMembers.fold(withMergedClients)(members => withMergedClients.copy(teamMembers = Some(members)))
+  }
+}
+
+object UpdateAccessGroupRequest {
+  implicit val format: OFormat[UpdateAccessGroupRequest] = Json.format[UpdateAccessGroupRequest]
+}
+
+case class AddMembersToAccessGroupRequest(teamMembers: Option[Set[AgentUser]], clients: Option[Set[Client]])
+
+object AddMembersToAccessGroupRequest {
+  implicit val format: OFormat[AddMembersToAccessGroupRequest] = Json.format[AddMembersToAccessGroupRequest]
+}

--- a/app/uk/gov/hmrc/agentpermissions/model/CustomAccessGroupRequests.scala
+++ b/app/uk/gov/hmrc/agentpermissions/model/CustomAccessGroupRequests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.agentpermissions.model
 
 import play.api.libs.json.{Json, OFormat}
@@ -6,14 +22,14 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, AgentUser, Arn, Clien
 import java.time.LocalDateTime
 
 case class CreateAccessGroupRequest(
-                                     groupName: String,
-                                     teamMembers: Option[Set[AgentUser]],
-                                     clients: Option[Set[Client]]
-                                   ) {
+  groupName: String,
+  teamMembers: Option[Set[AgentUser]],
+  clients: Option[Set[Client]]
+) {
   def buildAccessGroup(
-                        arn: Arn,
-                        agentUser: AgentUser
-                      ): AccessGroup = {
+    arn: Arn,
+    agentUser: AgentUser
+  ): AccessGroup = {
     val now = LocalDateTime.now()
 
     AccessGroup(
@@ -34,10 +50,10 @@ object CreateAccessGroupRequest {
 }
 
 case class UpdateAccessGroupRequest(
-                                     groupName: Option[String],
-                                     teamMembers: Option[Set[AgentUser]],
-                                     clients: Option[Set[Client]]
-                                   ) {
+  groupName: Option[String],
+  teamMembers: Option[Set[AgentUser]],
+  clients: Option[Set[Client]]
+) {
 
   def merge(existingAccessGroup: AccessGroup): AccessGroup = {
     val withMergedGroupName = groupName.fold(existingAccessGroup)(name =>

--- a/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
@@ -130,7 +130,7 @@ class AccessGroupsServiceImpl @Inject() (
       .map(accessGroups =>
         accessGroups
           .filter(_.clients.fold(false)(_.map(_.enrolmentKey).contains(enrolmentKey)))
-          .map(AccessGroupSummary.convert)
+          .map(AccessGroupSummary.convertCustomGroup)
       )
 
   override def getGroupSummariesForTeamMember(arn: Arn, userId: String)(implicit
@@ -141,7 +141,7 @@ class AccessGroupsServiceImpl @Inject() (
       .map(accessGroups =>
         accessGroups
           .filter(_.teamMembers.fold(false)(_.map(_.id).contains(userId)))
-          .map(AccessGroupSummary.convert)
+          .map(AccessGroupSummary.convertCustomGroup)
       )
 
   override def delete(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "7.12.0",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.74.0",
-    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.50.0-play-28",
+    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.51.0-play-28",
     "uk.gov.hmrc"             %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
     "uk.gov.hmrc"             %% "crypto-json-play-28"        % "7.3.0"
   )

--- a/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
@@ -248,7 +248,7 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
           status(result) shouldBe OK
           contentAsJson(result).as[Seq[AccessGroupSummary]] shouldBe Seq(
-            AccessGroupSummary(accessGroup._id.toHexString, accessGroup.groupName, 0, 0)
+            AccessGroupSummary(accessGroup._id.toHexString, accessGroup.groupName, Some(0), 0, isCustomGroup = true)
           )
         }
       }
@@ -432,14 +432,16 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
     "return only groups that the client is in" in new TestScope {
       mockAuthActionGetAuthorisedAgent(Some(AuthorisedAgent(arn, user)))
-      mockAccessGroupsServiceGetGroupsForClient(Seq(AccessGroupSummary(dbId.toHexString, groupName, 3, 3)))
+      mockAccessGroupsServiceGetGroupsForClient(
+        Seq(AccessGroupSummary(dbId.toHexString, groupName, Some(3), 3, isCustomGroup = true))
+      )
 
       val result = controller.getGroupSummariesForClient(arn, "key")(baseRequest)
 
       status(result) shouldBe OK
 
       contentAsJson(result) shouldBe Json.parse(
-        s"""[{"groupId":"${dbId.toHexString}","groupName":"$groupName","clientCount":3,"teamMemberCount":3}]"""
+        s"""[{"groupId":"${dbId.toHexString}","groupName":"$groupName","clientCount":3,"teamMemberCount":3,"isCustomGroup":true}]"""
       )
 
     }
@@ -468,14 +470,16 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
     "return only groups that the team member is in" in new TestScope {
       mockAuthActionGetAuthorisedAgent(Some(AuthorisedAgent(arn, user)))
-      mockAccessGroupsServiceGetGroupsForTeamMember(Seq(AccessGroupSummary(dbId.toHexString, groupName, 3, 3)))
+      mockAccessGroupsServiceGetGroupsForTeamMember(
+        Seq(AccessGroupSummary(dbId.toHexString, groupName, Some(3), 3, isCustomGroup = true))
+      )
 
       val result = controller.getGroupSummariesForTeamMember(arn, "key")(baseRequest)
 
       status(result) shouldBe OK
 
       contentAsJson(result) shouldBe Json.parse(
-        s"""[{"groupId":"${dbId.toHexString}","groupName":"$groupName","clientCount":3,"teamMemberCount":3}]"""
+        s"""[{"groupId":"${dbId.toHexString}","groupName":"$groupName","clientCount":3,"teamMemberCount":3,"isCustomGroup":true}]"""
       )
 
     }

--- a/test/uk/gov/hmrc/agentpermissions/controllers/UpdateAccessGroupRequestSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/UpdateAccessGroupRequestSpec.scala
@@ -17,6 +17,8 @@
 package uk.gov.hmrc.agentpermissions.controllers
 
 import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, AgentUser, Arn, Client}
+import uk.gov.hmrc.agentpermissions.model.UpdateAccessGroupRequest
+
 import uk.gov.hmrc.agentpermissions.BaseSpec
 
 import java.time.LocalDateTime

--- a/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
@@ -171,7 +171,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
         accessGroupsService
           .getGroupSummariesForClient(arn, s"$serviceCgt~$serviceIdentifierKeyCgt~XMCGTP123456789")
           .futureValue shouldBe
-          Seq(AccessGroupSummary(ag1._id.toHexString, "some group", 3, 3))
+          Seq(AccessGroupSummary(ag1._id.toHexString, "some group", Some(3), 3, isCustomGroup = true))
       }
     }
   }
@@ -189,7 +189,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
         )
 
         accessGroupsService.getGroupSummariesForTeamMember(arn, "user3").futureValue shouldBe
-          Seq(AccessGroupSummary(ag2._id.toHexString, "group 2", 3, 1))
+          Seq(AccessGroupSummary(ag2._id.toHexString, "group 2", Some(3), 1, isCustomGroup = true))
       }
     }
   }
@@ -478,9 +478,9 @@ class AccessGroupsServiceSpec extends BaseSpec {
 
     val clients = Seq(clientVat, clientPpt, clientCgt)
 
-    val accessGroupInMongo = withClientNamesRemoved(accessGroup)
+    val accessGroupInMongo: AccessGroup = withClientNamesRemoved(accessGroup)
 
-    val assignedClient = AssignedClient("service", Seq(Identifier("key", "value")), None, "user")
+    val assignedClient: AssignedClient = AssignedClient("service", Seq(Identifier("key", "value")), None, "user")
 
     implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
     implicit val headerCarrier: HeaderCarrier = HeaderCarrier()


### PR DESCRIPTION
- Readme updated with proposed endpoints for Tax service groups but no changes for them implemented
- Summaries are not stored anywhere so minimal impact to FE

- Aim will be for tax service groups to have it's own controller for new CRUD operations, however there are some endpoints in the existing controller that will need to be updated to account for both eg. groupNameCheck & summaries for client/team member