### PR TITLE
Apb 6963

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -70,7 +70,7 @@ class AccessGroupsController @Inject() (
   // gets all group summaries for client
   def getGroupSummariesForClient(arn: Arn, enrolmentKey: String): Action[AnyContent] = Action.async {
     implicit request =>
-      withAuthorisedAgent() { _ =>
+      withAuthorisedAgent(allowStandardUser = true) { _ =>
         groupsService
           .getAllGroupSummariesForClient(arn, enrolmentKey)
           .map(result => if (result.isEmpty) NotFound else Ok(Json.toJson(result)))

--- a/app/uk/gov/hmrc/agentpermissions/repository/TaxServiceGroupsRepository.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/TaxServiceGroupsRepository.scala
@@ -40,6 +40,7 @@ trait TaxServiceGroupsRepository {
   def get(arn: Arn): Future[Seq[TaxGroup]]
   def get(arn: Arn, groupName: String): Future[Option[TaxGroup]]
   def getByService(arn: Arn, service: String): Future[Option[TaxGroup]]
+  def groupExistsForTaxService(arn: Arn, service: String): Future[Boolean]
   def insert(accessGroup: TaxGroup): Future[Option[String]]
   def delete(arn: Arn, groupName: String): Future[Option[Long]]
   def update(arn: Arn, groupName: String, accessGroup: TaxGroup): Future[Option[Long]]
@@ -94,6 +95,15 @@ class TaxServiceGroupsRepositoryImpl @Inject() (
       .collation(caseInsensitiveCollation)
       .headOption()
       .map(_.map(_.decryptedValue))
+
+  def groupExistsForTaxService(arn: Arn, service: String): Future[Boolean] = {
+    val svc = if (service == "HMRC-TERSNT-ORG") "HMRC-TERS-ORG" else service // only TERS-ORG are stored
+    collection
+      .find(and(equal(FIELD_ARN, arn.value), equal(FIELD_SERVICE, svc)))
+      .collation(caseInsensitiveCollation)
+      .toFuture()
+      .map(_.nonEmpty)
+  }
 
   override def insert(accessGroup: TaxGroup): Future[Option[String]] =
     collection

--- a/app/uk/gov/hmrc/agentpermissions/service/TaxGroupsService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/TaxGroupsService.scala
@@ -21,7 +21,6 @@ import play.api.Logging
 import uk.gov.hmrc.agentmtdidentifiers.model._
 import uk.gov.hmrc.agentpermissions.connectors.UserClientDetailsConnector
 import uk.gov.hmrc.agentpermissions.repository.TaxServiceGroupsRepository
-import uk.gov.hmrc.agentpermissions.service.audit.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDateTime
@@ -75,22 +74,41 @@ trait TaxGroupsService {
 @Singleton
 class TaxGroupsServiceImpl @Inject() (
   taxServiceGroupsRepository: TaxServiceGroupsRepository,
-  userClientDetailsConnector: UserClientDetailsConnector,
-  auditService: AuditService
+  userClientDetailsConnector: UserClientDetailsConnector
 ) extends TaxGroupsService with Logging {
 
   override def clientCountForAvailableTaxServices(
     arn: Arn
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Map[String, Int]] =
-    for {
-      fullCount         <- userClientDetailsConnector.clientCountByTaxService(arn)
-      existingTaxGroups <- getAllTaxServiceGroups(arn)
+    userClientDetailsConnector.clientCountByTaxService(arn).flatMap {
+      case Some(fullMap) =>
+        Future
+          .sequence(
+            fullMap.map { entry =>
+              taxServiceGroupsRepository.groupExistsForTaxService(arn, entry._1).map {
+                case true  => None
+                case false => Some(entry)
+              }
+            }.toList
+          )
+          .map(_.flatten)
+          .map(_.toMap)
+          .map(consolidateTrustClients)
+      case None => Future successful Map[String, Int]()
+    }
 
-      taxServiceIds = existingTaxGroups.map(groups => groups.service)
-      combinedCount = fullCount.fold(Map.empty[String, Int])(fc => combineTrustCount(fc))
+  private val TERS = "HMRC-TERS-ORG"
+  private val TERSNT = "HMRC-TERSNT-ORG"
 
-      availableCount = combinedCount.filterNot(m => taxServiceIds.contains(m._1))
-    } yield availableCount
+  private def consolidateTrustClients(in: Map[String, Int]): Map[String, Int] = {
+    val tersCount = in.getOrElse(TERS, 0)
+    val tersntCount = in.getOrElse(TERSNT, 0)
+    val combinedCount = tersCount + tersntCount
+    val withoutTrustnt = in - TERSNT
+    if (combinedCount > 0)
+      withoutTrustnt + (TERS -> combinedCount)
+    else withoutTrustnt
+  }
 
   override def clientCountForTaxGroups(
     arn: Arn
@@ -106,8 +124,8 @@ class TaxGroupsServiceImpl @Inject() (
     } yield groupCount
 
   private def combineTrustCount(fullCount: Map[String, Int]): Map[String, Int] = {
-    val trustCounts = fullCount.filter(m => m._1.contains("HMRC-TERS"))
-    val combinedTrustCountValue = trustCounts.values.sum // total
+    val taxableTrustCounts = fullCount.filter(m => m._1.contains("HMRC-TERS"))
+    val combinedTrustCountValue = taxableTrustCounts.values.sum // total
 
     fullCount.filterNot(m => m._1.contains("HMRC-TERS")) ++ Map("HMRC-TERS" -> combinedTrustCountValue)
   }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-28"  % "7.13.0",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.74.0",
-    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.56.0-play-28",
+    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.60.0-play-28",
     "uk.gov.hmrc"             %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
     "uk.gov.hmrc"             %% "crypto-json-play-28"        % "7.3.0"
   )

--- a/test/uk/gov/hmrc/agentpermissions/repository/TaxServiceGroupsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/repository/TaxServiceGroupsRepositorySpec.scala
@@ -188,6 +188,21 @@ class TaxServiceGroupsRepositorySpec extends BaseSpec with DefaultPlayMongoRepos
       }
 
     }
+
+    "groupExistsForTaxService" when {
+      "access group exists for HMRC-TERS-ORG" should {
+        "return true when asked for HMRC-TERS-ORG" in new TestScope {
+          groupsRepository.insert(accessGroup.copy(service = "HMRC-TERS-ORG")).futureValue
+
+          groupsRepository.groupExistsForTaxService(arn, "HMRC-TERS-ORG").futureValue shouldBe true
+        }
+        "return true when asked for HMRC-TERSNT-ORG" in new TestScope {
+          groupsRepository.insert(accessGroup.copy(service = "HMRC-TERS-ORG")).futureValue
+
+          groupsRepository.groupExistsForTaxService(arn, "HMRC-TERSNT-ORG").futureValue shouldBe true
+        }
+      }
+    }
   }
 
   override protected def repository: PlayMongoRepository[SensitiveTaxServiceGroup] =


### PR DESCRIPTION
- refactoring to see if a TSG exists (rather than getting all group data out of mongo) 
- return the correct available tax service groups when no trust clients exist
- allow standards user on the get group summaries for client endpoint (which is used by the agent - todo rename this endpoint)