### PR TITLE
Sync improvements 3

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -376,7 +376,7 @@ class AccessGroupsController @Inject() (
         // Note: we are not waiting for this future to complete before returning a response
         eacdSynchronizer.syncWithEacd(matchedArn, authorisedAgent.agentUser, fullSync).onComplete {
           case Success(Some(updateStatuses)) =>
-            logger.info(s"EACD Sync request processed for ${arn.value} with update statuses: $updateStatuses")
+            logger.info(s"EACD Sync request processed for ${arn.value} with results: ${updateStatuses.mkString(", ")}")
           case Success(None) =>
             logger.info(s"EACD Sync request for ${arn.value} was not processed at this time.")
           case Failure(ex) =>

--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -374,7 +374,7 @@ class AccessGroupsController @Inject() (
     withAuthorisedAgent() { authorisedAgent =>
       withValidAndMatchingArn(arn, authorisedAgent) { matchedArn =>
         // Note: we are not waiting for this future to complete before returning a response
-        eacdSynchronizer.syncWithEacd(matchedArn, authorisedAgent.agentUser, fullSync).onComplete {
+        eacdSynchronizer.syncWithEacd(matchedArn, fullSync).onComplete {
           case Success(Some(updateStatuses)) =>
             logger.info(s"EACD Sync request processed for ${arn.value} with results: ${updateStatuses.mkString(", ")}")
           case Success(None) =>

--- a/app/uk/gov/hmrc/agentpermissions/service/EacdSynchronizer.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/EacdSynchronizer.scala
@@ -37,12 +37,19 @@ case class RemovalSet(enrolmentKeysToRemove: Set[String], userIdsToRemove: Set[S
   def isEmpty: Boolean = enrolmentKeysToRemove.isEmpty && userIdsToRemove.isEmpty
 }
 
+sealed trait SyncResult
+object SyncResult {
+  case object AccessGroupUpdateSuccess extends SyncResult
+  case object AccessGroupUpdateFailure extends SyncResult
+  case object AccessGroupUnchanged extends SyncResult
+}
+
 @ImplementedBy(classOf[EacdSynchronizerImpl])
 trait EacdSynchronizer {
   def syncWithEacd(arn: Arn, whoIsUpdating: AgentUser, fullSync: Boolean = false)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
-  ): Future[Option[Seq[AccessGroupUpdateStatus]]]
+  ): Future[Option[Map[SyncResult, Int]]]
 }
 
 @Singleton
@@ -205,7 +212,7 @@ class EacdSynchronizerImpl @Inject() (
 
   private[service] def persistAccessGroup(accessGroup: AccessGroup)(implicit
     ec: ExecutionContext
-  ): Future[AccessGroupUpdateStatus] = {
+  ): Future[SyncResult] = {
     logger.info(
       s"Updating access group of ${accessGroup.arn.value} having name '${accessGroup.groupName}'"
     )
@@ -215,14 +222,8 @@ class EacdSynchronizerImpl @Inject() (
       case taxGroup: TaxGroup =>
         taxServiceGroupsRepository.update(taxGroup.arn, taxGroup.groupName, taxGroup)
     }).map {
-      case None =>
-        AccessGroupNotUpdated
-      case Some(updatedCount) =>
-        if (updatedCount == 1L) {
-          AccessGroupUpdated
-        } else {
-          AccessGroupNotUpdated
-        }
+      case Some(updatedCount) if updatedCount == 1L => SyncResult.AccessGroupUpdateSuccess
+      case _                                        => SyncResult.AccessGroupUpdateFailure
     }
   }
 
@@ -264,7 +265,7 @@ class EacdSynchronizerImpl @Inject() (
   def syncWithEacd(arn: Arn, whoIsUpdating: AgentUser, fullSync: Boolean = false)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
-  ): Future[Option[Seq[AccessGroupUpdateStatus]]] = ifSyncShouldOccur(arn) {
+  ): Future[Option[Map[SyncResult, Int]]] = ifSyncShouldOccur(arn) {
     for {
       customAccessGroups <- accessGroupsRepository.get(arn)
       taxServiceGroups   <- taxServiceGroupsRepository.get(arn)
@@ -280,10 +281,16 @@ class EacdSynchronizerImpl @Inject() (
       // Remove clients and members that are no longer with the agency from any stored access groups.
       updatedAccessGroups <- Future.traverse(allAccessGroups)(applyRemovalSet(_, removalSet, whoIsUpdating))
 
+      // Determine which access groups have actually changed
+      accessGroupsToPersist = allAccessGroups.zip(updatedAccessGroups).collect {
+                                case (old, updated) if updated.lastUpdated != old.lastUpdated => updated
+                              }
+      nrUnchangedAccessGroups = updatedAccessGroups.size - accessGroupsToPersist.size
+
       // Persist the updated access groups.
-      updateStatuses: Seq[AccessGroupUpdateStatus] <-
+      updateStatuses: Seq[SyncResult] <-
         if (removalSet.isEmpty) Future.successful(Seq.empty)
-        else Future.traverse(updatedAccessGroups)(persistAccessGroup(_))
+        else Future.traverse(accessGroupsToPersist)(persistAccessGroup(_))
 
       // Optionally ensure that in EACD the enrolment assignments match those kept by agent-permissions.
       // This is scheduled asynchronously as it could take some time.
@@ -291,6 +298,10 @@ class EacdSynchronizerImpl @Inject() (
             doFullSync(arn, updatedAccessGroups.collect { case cg: CustomGroup => cg })
           }
           else ()
-    } yield updateStatuses
+    } yield Map[SyncResult, Int](
+      SyncResult.AccessGroupUpdateSuccess -> updateStatuses.count(_ == SyncResult.AccessGroupUpdateSuccess),
+      SyncResult.AccessGroupUpdateFailure -> updateStatuses.count(_ == SyncResult.AccessGroupUpdateFailure),
+      SyncResult.AccessGroupUnchanged     -> nrUnchangedAccessGroups
+    ).filter(_._2 > 0)
   }
 }

--- a/app/uk/gov/hmrc/agentpermissions/service/EacdSynchronizer.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/EacdSynchronizer.scala
@@ -46,7 +46,7 @@ object SyncResult {
 
 @ImplementedBy(classOf[EacdSynchronizerImpl])
 trait EacdSynchronizer {
-  def syncWithEacd(arn: Arn, whoIsUpdating: AgentUser, fullSync: Boolean = false)(implicit
+  def syncWithEacd(arn: Arn, fullSync: Boolean = false)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Option[Map[SyncResult, Int]]]
@@ -262,10 +262,11 @@ class EacdSynchronizerImpl @Inject() (
     *   None if sync was not done (if too soon after previous sync or items still outstanding). A list of update
     *   statuses otherwise
     */
-  def syncWithEacd(arn: Arn, whoIsUpdating: AgentUser, fullSync: Boolean = false)(implicit
+  def syncWithEacd(arn: Arn, fullSync: Boolean = false)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Option[Map[SyncResult, Int]]] = ifSyncShouldOccur(arn) {
+    val whoIsUpdating = AgentUser(id = "", name = "EACD sync")
     for {
       customAccessGroups <- accessGroupsRepository.get(arn)
       taxServiceGroups   <- taxServiceGroupsRepository.get(arn)

--- a/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
@@ -260,16 +260,16 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
     def mockEacdSynchronizerSyncWithEacdNoException(results: Map[SyncResult, Int] = Map.empty): Unit =
       (mockEacdSynchronizer
-        .syncWithEacd(_: Arn, _: AgentUser, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *, *)
+        .syncWithEacd(_: Arn, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *, *, *)
         .returning(Future.successful(Some(results)))
 
     def mockEacdSynchronizerSyncWithEacdHasException(
       ex: Exception
     ): Unit =
       (mockEacdSynchronizer
-        .syncWithEacd(_: Arn, _: AgentUser, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *, *)
+        .syncWithEacd(_: Arn, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *, *, *)
         .returning(Future.failed(ex))
 
     def mockGroupsServiceGetGroupSummariesForClient(

--- a/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
@@ -258,13 +258,11 @@ class AccessGroupsControllerSpec extends BaseSpec {
         .expects(*, *, *)
         .returning(Future.failed(ex))
 
-    def mockEacdSynchronizerSyncWithEacdNoException(
-      accessGroupUpdateStatuses: Seq[AccessGroupUpdateStatus]
-    ): Unit =
+    def mockEacdSynchronizerSyncWithEacdNoException(results: Map[SyncResult, Int] = Map.empty): Unit =
       (mockEacdSynchronizer
         .syncWithEacd(_: Arn, _: AgentUser, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
         .expects(*, *, *, *, *)
-        .returning(Future.successful(Some(accessGroupUpdateStatuses)))
+        .returning(Future.successful(Some(results)))
 
     def mockEacdSynchronizerSyncWithEacdHasException(
       ex: Exception
@@ -1525,7 +1523,7 @@ class AccessGroupsControllerSpec extends BaseSpec {
         "sync is successful" should {
           s"return $OK" in new TestScope {
             mockAuthActionGetAuthorisedAgent(Some(AuthorisedAgent(arn, user)))
-            mockEacdSynchronizerSyncWithEacdNoException(Seq(AccessGroupUpdated))
+            mockEacdSynchronizerSyncWithEacdNoException(Map(SyncResult.AccessGroupUpdateSuccess -> 42))
 
             val result = controller.syncWithEacd(arn)(baseRequest)
 

--- a/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
@@ -20,6 +20,7 @@ import akka.actor.ActorSystem
 import org.bson.types.ObjectId
 import org.scalamock.handlers.{CallHandler3, CallHandler4, CallHandler5, CallHandler7}
 import play.api.libs.json.{JsArray, JsNumber, JsString, JsValue, Json}
+import play.api.mvc.Results.Accepted
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Request}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -263,7 +264,7 @@ class AccessGroupsControllerSpec extends BaseSpec {
       (mockEacdSynchronizer
         .syncWithEacd(_: Arn, _: AgentUser, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
         .expects(*, *, *, *, *)
-        .returning(Future.successful(accessGroupUpdateStatuses))
+        .returning(Future.successful(Some(accessGroupUpdateStatuses)))
 
     def mockEacdSynchronizerSyncWithEacdHasException(
       ex: Exception
@@ -1528,7 +1529,7 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
             val result = controller.syncWithEacd(arn)(baseRequest)
 
-            status(result) shouldBe OK
+            status(result) shouldBe ACCEPTED
           }
         }
 
@@ -1539,7 +1540,7 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
             val result = controller.syncWithEacd(arn)(baseRequest)
 
-            status(result) shouldBe OK
+            status(result) shouldBe ACCEPTED
           }
         }
       }

--- a/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
@@ -59,7 +59,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       (mockAccessGroupsRepository.get(_: Arn)).expects(arn).returning(Future.successful(Seq.empty))
       (stubTaxServiceGroupsRepository.get(_: Arn)).when(arn).returns(Future.successful(Seq.empty))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Seq.empty)
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Map.empty)
     }
 
     "do the sync if all conditions are satisfied" in new TestScope {
@@ -83,7 +83,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       expectAuditTeamMembersRemoval()
       expectAccessGroupsRepositoryUpdate(Some(1))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Seq(AccessGroupUpdated))
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Map(SyncResult.AccessGroupUpdateSuccess -> 1))
     }
   }
 
@@ -119,7 +119,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
           eacdSynchronizer
             .syncWithEacd(arn, agentUser1)
-            .futureValue shouldBe Some(Seq(AccessGroupUpdated))
+            .futureValue shouldBe Some(Map(SyncResult.AccessGroupUpdateSuccess -> 1))
         }
       }
 
@@ -167,7 +167,7 @@ class EacdSynchronizerSpec extends BaseSpec {
               arn,
               agentUser1
             )
-            .futureValue shouldBe Some(Seq.empty)
+            .futureValue shouldBe Some(Map(SyncResult.AccessGroupUnchanged -> 1))
         }
       }
     }
@@ -297,7 +297,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
         expectAccessGroupsRepositoryUpdate(None)
 
-        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe AccessGroupNotUpdated
+        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe SyncResult.AccessGroupUpdateFailure
       }
     }
 
@@ -308,7 +308,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
         expectAccessGroupsRepositoryUpdate(Some(1))
 
-        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe AccessGroupUpdated
+        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe SyncResult.AccessGroupUpdateSuccess
       }
     }
 
@@ -319,7 +319,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
         expectAccessGroupsRepositoryUpdate(Some(0))
 
-        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe AccessGroupNotUpdated
+        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe SyncResult.AccessGroupUpdateFailure
       }
     }
 
@@ -330,7 +330,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
         expectTaxGroupsRepositoryUpdate(Some(1))
 
-        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe AccessGroupUpdated
+        eacdSynchronizer.persistAccessGroup(accessGroup).futureValue shouldBe SyncResult.AccessGroupUpdateSuccess
       }
     }
 

--- a/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
@@ -37,19 +37,19 @@ class EacdSynchronizerSpec extends BaseSpec {
 
     "not sync if outstanding work items cannot be determined" in new TestScope {
       outstandingAssignmentsWorkItemsExist(None)
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Seq.empty
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
     }
 
     "not sync if outstanding assignment work items exist" in new TestScope {
       outstandingAssignmentsWorkItemsExist(Some(true))
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Seq.empty
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
     }
 
     "not sync if there are no outstanding assignment work items but EACD sync token is not acquired" in new TestScope {
       outstandingAssignmentsWorkItemsExist(Some(false))
       appConfigEacdSetSeconds(10)
       syncRepoCannotBeAcquired()
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Seq.empty
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
     }
 
     "not sync if there are no outstanding assignment work items, EACD sync token is acquired but there are no access groups" in new TestScope {
@@ -59,7 +59,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       (mockAccessGroupsRepository.get(_: Arn)).expects(arn).returning(Future.successful(Seq.empty))
       (stubTaxServiceGroupsRepository.get(_: Arn)).when(arn).returns(Future.successful(Seq.empty))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Seq.empty
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Seq.empty)
     }
 
     "do the sync if all conditions are satisfied" in new TestScope {
@@ -83,7 +83,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       expectAuditTeamMembersRemoval()
       expectAccessGroupsRepositoryUpdate(Some(1))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Seq(AccessGroupUpdated)
+      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Seq(AccessGroupUpdated))
     }
   }
 
@@ -119,7 +119,7 @@ class EacdSynchronizerSpec extends BaseSpec {
 
           eacdSynchronizer
             .syncWithEacd(arn, agentUser1)
-            .futureValue shouldBe Seq(AccessGroupUpdated)
+            .futureValue shouldBe Some(Seq(AccessGroupUpdated))
         }
       }
 
@@ -167,7 +167,7 @@ class EacdSynchronizerSpec extends BaseSpec {
               arn,
               agentUser1
             )
-            .futureValue shouldBe Seq.empty
+            .futureValue shouldBe Some(Seq.empty)
         }
       }
     }

--- a/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/EacdSynchronizerSpec.scala
@@ -37,19 +37,19 @@ class EacdSynchronizerSpec extends BaseSpec {
 
     "not sync if outstanding work items cannot be determined" in new TestScope {
       outstandingAssignmentsWorkItemsExist(None)
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
+      eacdSynchronizer.syncWithEacd(arn).futureValue shouldBe None
     }
 
     "not sync if outstanding assignment work items exist" in new TestScope {
       outstandingAssignmentsWorkItemsExist(Some(true))
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
+      eacdSynchronizer.syncWithEacd(arn).futureValue shouldBe None
     }
 
     "not sync if there are no outstanding assignment work items but EACD sync token is not acquired" in new TestScope {
       outstandingAssignmentsWorkItemsExist(Some(false))
       appConfigEacdSetSeconds(10)
       syncRepoCannotBeAcquired()
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe None
+      eacdSynchronizer.syncWithEacd(arn).futureValue shouldBe None
     }
 
     "not sync if there are no outstanding assignment work items, EACD sync token is acquired but there are no access groups" in new TestScope {
@@ -59,7 +59,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       (mockAccessGroupsRepository.get(_: Arn)).expects(arn).returning(Future.successful(Seq.empty))
       (stubTaxServiceGroupsRepository.get(_: Arn)).when(arn).returns(Future.successful(Seq.empty))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Map.empty)
+      eacdSynchronizer.syncWithEacd(arn).futureValue shouldBe Some(Map.empty)
     }
 
     "do the sync if all conditions are satisfied" in new TestScope {
@@ -83,7 +83,7 @@ class EacdSynchronizerSpec extends BaseSpec {
       expectAuditTeamMembersRemoval()
       expectAccessGroupsRepositoryUpdate(Some(1))
 
-      eacdSynchronizer.syncWithEacd(arn, user).futureValue shouldBe Some(Map(SyncResult.AccessGroupUpdateSuccess -> 1))
+      eacdSynchronizer.syncWithEacd(arn).futureValue shouldBe Some(Map(SyncResult.AccessGroupUpdateSuccess -> 1))
     }
   }
 
@@ -118,7 +118,7 @@ class EacdSynchronizerSpec extends BaseSpec {
           expectAccessGroupsRepositoryUpdate(Some(1))
 
           eacdSynchronizer
-            .syncWithEacd(arn, agentUser1)
+            .syncWithEacd(arn)
             .futureValue shouldBe Some(Map(SyncResult.AccessGroupUpdateSuccess -> 1))
         }
       }
@@ -163,10 +163,7 @@ class EacdSynchronizerSpec extends BaseSpec {
           doNotExpectAccessGroupsRepositoryUpdate()
 
           eacdSynchronizer
-            .syncWithEacd(
-              arn,
-              agentUser1
-            )
+            .syncWithEacd(arn)
             .futureValue shouldBe Some(Map(SyncResult.AccessGroupUnchanged -> 1))
         }
       }


### PR DESCRIPTION
* Improve sync logging
* Avoid updating groups in mongo which have not changed
* Use 'EACD sync' as 'last updated by' when a group is modified by the sync