### PR TITLE
APB-7070 [CS] methods to enable querying mongo for UserAssignments

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepository.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepository.scala
@@ -46,8 +46,10 @@ trait AccessGroupsRepository {
   def get(arn: Arn, groupName: String): Future[Option[CustomGroup]]
 
   /* TODO APB-7070: add following functionality
-   *   - find client in group by ids
-   *   - find team member in group by ids (decrypted)
+   *   [ ] pull list of tm from group
+   *   [ ] pull list of clients from group
+   *   [ ] find client in group by ids
+   *   [ ] find team member in group by ids (decrypted)
    *  to be used for find Client & Team member pair in group by ids
    *
    * */

--- a/app/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepository.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/AccessGroupsRepository.scala
@@ -45,6 +45,13 @@ trait AccessGroupsRepository {
 
   def get(arn: Arn, groupName: String): Future[Option[CustomGroup]]
 
+  /* TODO APB-7070: add following functionality
+   *   - find client in group by ids
+   *   - find team member in group by ids (decrypted)
+   *  to be used for find Client & Team member pair in group by ids
+   *
+   * */
+
   def insert(accessGroup: CustomGroup): Future[Option[String]]
 
   def delete(arn: Arn, groupName: String): Future[Option[Long]]

--- a/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
@@ -274,10 +274,11 @@ class AccessGroupsServiceImpl @Inject() (
         case _ => AccessGroupNotUpdated
       })
 
-  /* TODO APB-7066: updates whoIsUpdating (via repo?)
-   *   + get team member & clients in group to calculate assignments
-   *   + push maybe assignments
-   *   + auditing update
+  /* TODO APB-7067:
+   *    [ ] updates whoIsUpdating (via repo?)
+   *    [ ] get team member & clients in group to calculate assignments
+   *    [ ] push maybe assignments
+   *    [ ] auditing update
    * */
   def removeTeamMember(groupId: String, teamMemberId: String, whoIsUpdating: AgentUser)(implicit
     hc: HeaderCarrier,

--- a/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
@@ -258,6 +258,11 @@ class AccessGroupsServiceImpl @Inject() (
                                  }
     } yield accessGroupUpdateStatus
 
+  /* TODO APB-7066: updates whoIsUpdating (via repo?)
+   *   + get client & team members in group to calculate assignments
+   *   + push maybe assignments
+   *   + auditing update
+   * */
   def removeClient(groupId: String, clientId: String, whoIsUpdating: AgentUser)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -265,10 +270,15 @@ class AccessGroupsServiceImpl @Inject() (
     accessGroupsRepository
       .removeClient(groupId, clientId)
       .map(_.getMatchedCount match {
-        case 1 => AccessGroupUpdatedWithoutAssignmentsPushed // TODO push assignments
+        case 1 => AccessGroupUpdatedWithoutAssignmentsPushed
         case _ => AccessGroupNotUpdated
       })
 
+  /* TODO APB-7066: updates whoIsUpdating (via repo?)
+   *   + get team member & clients in group to calculate assignments
+   *   + push maybe assignments
+   *   + auditing update
+   * */
   def removeTeamMember(groupId: String, teamMemberId: String, whoIsUpdating: AgentUser)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -283,7 +293,7 @@ class AccessGroupsServiceImpl @Inject() (
           accessGroupsRepository
             .update(accessGroup.arn, accessGroup.groupName, updatedGroup)
             .map {
-              case Some(1) => AccessGroupUpdatedWithoutAssignmentsPushed // TODO push assignments
+              case Some(1) => AccessGroupUpdatedWithoutAssignmentsPushed
               case _       => AccessGroupNotUpdated
             }
         case None => Future successful AccessGroupNotUpdated

--- a/app/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/userenrolment/UserEnrolmentAssignmentService.scala
@@ -116,14 +116,14 @@ class UserEnrolmentAssignmentServiceImpl @Inject() (
     for {
       /* TODO: Replace pulling existing access groups with mongo query for pairs of UserEnrolments
        *   eg. maxNetChangePairs <- userEnrolmentAssignmentCalculator.pairUserEnrolments(Set[AgentUser], Set[Client])
-       *       foundPairs <- accessGroupsRepository.findPairs(pairs)
+       *       foundPairs <- accessGroupsRepository.findPairs(arn, pairs) //needs decryption mongo work?
        *       maybeUserEnrolmentAssignments <-
-       *         Future.successful(userEnrolmentAssignmentCalculator.assessPairs(maxNetChangePairs, foundPairs))
+       *         Future.successful(userEnrolmentAssignmentCalculator.assessUserEnrolmentPairs(maxNetChangePairs, foundPairs))
        */
       existingAccessGroups <- accessGroupsRepository.get(groupId.arn)
       maybeUserEnrolmentAssignments <-
         Future.successful(
-          userEnrolmentAssignmentCalculator.forAddToGroup(clients, teamMembers, existingAccessGroups, groupId.encode)
+          userEnrolmentAssignmentCalculator.forAddToGroup(clients, teamMembers, existingAccessGroups, groupId)
         )
     } yield maybeUserEnrolmentAssignments
 
@@ -138,7 +138,7 @@ class UserEnrolmentAssignmentServiceImpl @Inject() (
       maybeUserEnrolmentAssignments <-
         Future.successful(
           userEnrolmentAssignmentCalculator
-            .forRemoveFromGroup(clients, teamMembers, existingAccessGroups, groupId.encode)
+            .forRemoveFromGroup(clients, teamMembers, existingAccessGroups, groupId)
         )
     } yield maybeUserEnrolmentAssignments
 


### PR DESCRIPTION
In UserAssignmentService
split update into calculateForRemoveFromGroup (could merge again - thoughts?) I think splitting it just helped me understand where the proposed change to using a mongo query on the pairs would be

In UserAssignmentCalculator
added `pairUserEnrolments` and `assessUserEnrolmentPairs` to be used in UserAssignmentService once we are able to query mongo for the pairs

TODOs scoped out for APB-7067 & APB-7066 for updating user assignments in EACD.
Note: there's no getting around needing one of the full lists for calculating the assignments (removing team member needs full list of clients, removing client needs full team member list) but we could improve how we update who is updating and how we audit etc.