### PR TITLE
[CS] WIP update whoIsUpdating via repo - do not merge

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
+++ b/app/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsController.scala
@@ -354,10 +354,10 @@ class AccessGroupsController @Inject() (
   }
 
   def addTeamMemberToGroup(gid: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    withAuthorisedAgent() { _ =>
+    withAuthorisedAgent() { authorisedAgent =>
       withJsonParsed[AddOneTeamMemberToGroupRequest] { addRequest =>
         accessGroupsService
-          .addMemberToGroup(gid, addRequest.teamMember) map {
+          .addMemberToGroup(gid, addRequest.teamMember, authorisedAgent.agentUser) map {
 //          case AccessGroupUpdated => Ok
           case AccessGroupUpdatedWithoutAssignmentsPushed =>
             logger.info(s"Custom group added a team member, but assignments were not pushed")

--- a/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/AccessGroupsService.scala
@@ -32,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[AccessGroupsServiceImpl])
 trait AccessGroupsService {
-  def addMemberToGroup(gid: String, teamMember: AgentUser)(implicit
+  def addMemberToGroup(gid: String, teamMember: AgentUser, whoIsUpdating: AgentUser)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[AccessGroupUpdateStatus]
@@ -288,6 +288,10 @@ class AccessGroupsServiceImpl @Inject() (
                   clientToRemove,
                   usersInGroup
                 )
+//            maybeUpdatedCount <- accessGroupsRepository.removeClient(groupId, clientId, whoIsUpdating)
+//            updateStatus <- maybeUpdatedCount match {
+//              case updatedCount =>
+//                if (updatedCount.getModifiedCount == 1) {
             maybeUpdatedCount <- accessGroupsRepository.update(accessGroup.arn, accessGroup.groupName, updatedGroup)
             updateStatus <- maybeUpdatedCount match {
                               case Some(updatedCount) =>
@@ -486,12 +490,12 @@ class AccessGroupsServiceImpl @Inject() (
         }
     }
 
-  override def addMemberToGroup(groupId: String, teamMember: AgentUser)(implicit
+  override def addMemberToGroup(groupId: String, teamMember: AgentUser, whoIsUpdating: AgentUser)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[AccessGroupUpdateStatus] =
     accessGroupsRepository
-      .addTeamMember(groupId, teamMember)
+      .addTeamMember(groupId, teamMember, whoIsUpdating)
       .map(_.getMatchedCount match {
         case 1 => AccessGroupUpdatedWithoutAssignmentsPushed // TODO push assignments
         case _ => AccessGroupNotUpdated

--- a/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/controllers/AccessGroupsControllerSpec.scala
@@ -182,10 +182,10 @@ class AccessGroupsControllerSpec extends BaseSpec {
 
     def expectAddTeamMemberToGroup(
       accessGroupUpdateStatus: AccessGroupUpdateStatus
-    ): CallHandler4[String, AgentUser, HeaderCarrier, ExecutionContext, Future[AccessGroupUpdateStatus]] =
+    ): CallHandler5[String, AgentUser, AgentUser, HeaderCarrier, ExecutionContext, Future[AccessGroupUpdateStatus]] =
       (mockAccessGroupsService
-        .addMemberToGroup(_: String, _: AgentUser)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *)
+        .addMemberToGroup(_: String, _: AgentUser, _: AgentUser)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *, *, *, *)
         .returning(Future.successful(accessGroupUpdateStatus))
         .once()
 

--- a/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/AccessGroupsServiceSpec.scala
@@ -200,21 +200,21 @@ class AccessGroupsServiceSpec extends BaseSpec {
       groupId: String,
       member: AgentUser,
       updatedCount: Int = 1
-    ): CallHandler2[String, AgentUser, Future[UpdateResult]] =
+    ): CallHandler3[String, AgentUser, AgentUser, Future[UpdateResult]] =
       (mockAccessGroupsRepository
-        .addTeamMember(_: String, _: AgentUser))
-        .expects(groupId, member)
+        .addTeamMember(_: String, _: AgentUser, _: AgentUser))
+        .expects(groupId, member, user1)
         .returning(Future.successful(UpdateResult.acknowledged(updatedCount, updatedCount, null)))
 
     def mockAddRemoveClientFromGroup(
       groupId: String,
       client: Client,
       updatedCount: Int = 1
-    ): CallHandler2[String, String, Future[UpdateResult]] = {
+    ): CallHandler3[String, String, AgentUser, Future[UpdateResult]] = {
       val updateResult = UpdateResult.acknowledged(updatedCount, updatedCount, null)
       (mockAccessGroupsRepository
-        .removeClient(_: String, _: String))
-        .expects(groupId, client.enrolmentKey)
+        .removeClient(_: String, _: String, _: AgentUser))
+        .expects(groupId, client.enrolmentKey, user)
         .returning(Future.successful(updateResult))
     }
 
@@ -742,7 +742,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
       s"return $AccessGroupUpdatedWithoutAssignmentsPushed" in new TestScope {
         mockAddTeamMemberToGroup(dbId.toString, user, 1)
         accessGroupsService
-          .addMemberToGroup(dbId.toString, user)
+          .addMemberToGroup(dbId.toString, user, user1)
           .futureValue shouldBe AccessGroupUpdatedWithoutAssignmentsPushed
       }
     }
@@ -750,7 +750,7 @@ class AccessGroupsServiceSpec extends BaseSpec {
     "works as expected when no update made due to group not found or something " should {
       s"return $AccessGroupNotUpdated" in new TestScope {
         mockAddTeamMemberToGroup(dbId.toString, user, 0)
-        accessGroupsService.addMemberToGroup(dbId.toString, user).futureValue shouldBe AccessGroupNotUpdated
+        accessGroupsService.addMemberToGroup(dbId.toString, user, user1).futureValue shouldBe AccessGroupNotUpdated
       }
     }
 


### PR DESCRIPTION
This branch `repo-who-is-updating` is to look into a combined update to include whoIsUpdating for `addTeamMember` and `removeClient` but it still has the issue of updating who is updating even if there is no client removed by the pull

Note: We only have createdBy and lastUpdatedBy fields, there's not really an update history without looking at the auditing logs. These could be quite hard to read since it logs the whole group [ in chunks if needed ], rather than a NET change (from the user perspective, not assignments).

I get the value of storing it with the access group, but we might want to focus on a different solution altogether for tracking who updates? Otherwise we should remove these methods and stick with the mongo update that replaces the whole group.