### PR TITLE
APB-11870: add encryption key rotation utility

### DIFF
--- a/app/uk/gov/hmrc/agentpermissions/MigrationsModule.scala
+++ b/app/uk/gov/hmrc/agentpermissions/MigrationsModule.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions
+
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+import uk.gov.hmrc.agentpermissions.service.KeyRotationService
+
+class MigrationsModule extends Module:
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[?]] =
+    Seq(
+      bind[KeyRotationService].toSelf.eagerly()
+    )

--- a/app/uk/gov/hmrc/agentpermissions/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentpermissions/config/AppConfig.scala
@@ -33,6 +33,7 @@ trait AppConfig {
   def accessGroupChunkSize: Int
   def useEnrolmentAssignmentsChunkSize: Int
   def eacdSyncNotBeforeSeconds: Int
+  def keyRotation: KeyRotationConfig
 }
 
 @Singleton
@@ -47,4 +48,5 @@ class AppConfigImpl @Inject() (servicesConfig: ServicesConfig, configuration: Co
   override lazy val useEnrolmentAssignmentsChunkSize: Int =
     servicesConfig.getInt("audit.user-enrolment-assignments-chunk-size")
   override lazy val eacdSyncNotBeforeSeconds: Int = configuration.underlying.getInt("eacdsync.notBeforeSeconds")
+  override lazy val keyRotation: KeyRotationConfig = configuration.get[KeyRotationConfig]("keyRotation")
 }

--- a/app/uk/gov/hmrc/agentpermissions/config/KeyRotationConfig.scala
+++ b/app/uk/gov/hmrc/agentpermissions/config/KeyRotationConfig.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.config
+
+import com.typesafe.config.Config
+import play.api.{ConfigLoader, Configuration}
+
+import scala.concurrent.duration.FiniteDuration
+
+case class KeyRotationConfig(
+  enabled: Boolean,
+  maxTotalDuration: FiniteDuration,
+  batchSize: Int
+)
+
+object KeyRotationConfig:
+  given ConfigLoader[KeyRotationConfig] with
+    override def load(config: Config, path: String): KeyRotationConfig =
+      val obj = Configuration(config.getConfig(path))
+      KeyRotationConfig(
+        obj.get[Boolean]("enabled"),
+        obj.get[FiniteDuration]("maxTotalDuration").toCoarsest,
+        obj.get[Int]("batchSize")
+      )

--- a/app/uk/gov/hmrc/agentpermissions/model/SensitiveCustomGroup.scala
+++ b/app/uk/gov/hmrc/agentpermissions/model/SensitiveCustomGroup.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.agentpermissions.model
 
 import play.api.libs.json.*
 import uk.gov.hmrc.agentpermissions.model.Arn
-import uk.gov.hmrc.agentpermissions.models.GroupId
 import uk.gov.hmrc.agentpermissions.model.accessgroups.CustomGroup
+import uk.gov.hmrc.agentpermissions.models.GroupId
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, Sensitive}
 
 import java.time.LocalDateTime

--- a/app/uk/gov/hmrc/agentpermissions/model/SensitiveTaxGroup.scala
+++ b/app/uk/gov/hmrc/agentpermissions/model/SensitiveTaxGroup.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.agentpermissions.model
 
 import play.api.libs.json.*
 import uk.gov.hmrc.agentpermissions.model.Arn
-import uk.gov.hmrc.agentpermissions.models.GroupId
 import uk.gov.hmrc.agentpermissions.model.accessgroups.TaxGroup
+import uk.gov.hmrc.agentpermissions.models.GroupId
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, Sensitive}
 
 import java.time.LocalDateTime

--- a/app/uk/gov/hmrc/agentpermissions/repository/CustomGroupsRepositoryV2.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/CustomGroupsRepositoryV2.scala
@@ -20,17 +20,18 @@ import com.google.inject.ImplementedBy
 import com.mongodb.MongoWriteException
 import com.mongodb.client.model.{Collation, IndexOptions}
 import org.mongodb.scala.bson.Document
+import org.mongodb.scala.model.*
 import org.mongodb.scala.model.CollationStrength.SECONDARY
 import org.mongodb.scala.model.Filters.{and, equal}
 import org.mongodb.scala.model.Indexes.{ascending, compoundIndex}
-import org.mongodb.scala.model.*
 import org.mongodb.scala.result.UpdateResult
 import play.api.Logging
 import play.api.libs.json.Format
+import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, CustomGroup}
 import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveAgentUser, SensitiveCustomGroup}
 import uk.gov.hmrc.agentpermissions.models.GroupId
 import uk.gov.hmrc.agentpermissions.repository.CustomGroupsRepositoryV2Impl.*
-import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, CustomGroup}
+import uk.gov.hmrc.agentpermissions.util.{Migrations, PlayMongoMigrations}
 import uk.gov.hmrc.crypto.Sensitive.SensitiveString
 import uk.gov.hmrc.crypto.json.JsonEncryption
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, PlainText}
@@ -41,7 +42,7 @@ import javax.inject.{Inject, Named, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[CustomGroupsRepositoryV2Impl])
-trait CustomGroupsRepositoryV2 {
+trait CustomGroupsRepositoryV2 extends Migrations {
 
   /* TODO: add following functionality
    *   [ ] pull list of tm from group
@@ -70,7 +71,7 @@ trait CustomGroupsRepositoryV2 {
 
 @Singleton
 class CustomGroupsRepositoryV2Impl @Inject() (
-  mongoComponent: MongoComponent,
+  val mongoComponent: MongoComponent,
   @Named("aes") crypto: Encrypter & Decrypter
 )(using ec: ExecutionContext)
     extends PlayMongoRepository[SensitiveCustomGroup](
@@ -91,7 +92,7 @@ class CustomGroupsRepositoryV2Impl @Inject() (
         // Sensitive string codec so we can operate on individual string fields
         Codecs.playFormatCodec(sensitiveStringFormat(using crypto))
       )
-    ) with CustomGroupsRepositoryV2 with Logging {
+    ) with CustomGroupsRepositoryV2 with PlayMongoMigrations with Logging {
 
   // Ensure that we are using a deterministic cryptographic algorithm, or we won't be able to search on encrypted fields
   require(

--- a/app/uk/gov/hmrc/agentpermissions/repository/OptinRepository.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/OptinRepository.scala
@@ -22,19 +22,19 @@ import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model.IndexModel
 import org.mongodb.scala.model.Indexes.ascending
 import play.api.Logging
-import uk.gov.hmrc.agentpermissions.model.Arn
-import uk.gov.hmrc.agentpermissions.model.SensitiveOptinRecord
 import uk.gov.hmrc.agentpermissions.model.accessgroups.optin.*
+import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveOptinRecord}
+import uk.gov.hmrc.agentpermissions.repository.UpsertType.{RecordInserted, RecordUpdated}
+import uk.gov.hmrc.agentpermissions.util.{Migrations, PlayMongoMigrations}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
 import javax.inject.{Inject, Named, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.agentpermissions.repository.UpsertType.{RecordInserted, RecordUpdated}
 
 @ImplementedBy(classOf[OptinRepositoryImpl])
-trait OptinRepository {
+trait OptinRepository extends Migrations {
   def get(arn: Arn): Future[Option[OptinRecord]]
   def upsert(optinRecord: OptinRecord): Future[Option[UpsertType]]
   def getAll(): Future[Seq[OptinRecord]]
@@ -44,7 +44,7 @@ trait OptinRepository {
 
 @Singleton
 class OptinRepositoryImpl @Inject() (
-  mongoComponent: MongoComponent,
+  val mongoComponent: MongoComponent,
   @Named("aes") crypto: Encrypter & Decrypter
 )(using ec: ExecutionContext)
     extends PlayMongoRepository[SensitiveOptinRecord](
@@ -54,7 +54,8 @@ class OptinRepositoryImpl @Inject() (
       indexes = Seq(
         IndexModel(ascending("arn"), new IndexOptions().name("arnIdx").unique(true))
       )
-    ) with OptinRepository with Logging {
+    ) with OptinRepository with PlayMongoMigrations with Logging {
+
   def get(arn: Arn): Future[Option[OptinRecord]] =
     collection.find(equal("arn", arn.value)).headOption().map(_.map(_.decryptedValue))
 

--- a/app/uk/gov/hmrc/agentpermissions/repository/TaxGroupsRepositoryV2.scala
+++ b/app/uk/gov/hmrc/agentpermissions/repository/TaxGroupsRepositoryV2.scala
@@ -19,15 +19,16 @@ package uk.gov.hmrc.agentpermissions.repository
 import com.google.inject.ImplementedBy
 import com.mongodb.MongoWriteException
 import com.mongodb.client.model.{Collation, IndexOptions}
+import org.mongodb.scala.model.*
 import org.mongodb.scala.model.CollationStrength.SECONDARY
 import org.mongodb.scala.model.Filters.{and, equal}
 import org.mongodb.scala.model.Indexes.{ascending, compoundIndex}
-import org.mongodb.scala.model.*
 import org.mongodb.scala.result.UpdateResult
 import play.api.Logging
+import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, TaxGroup}
 import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveAgentUser, SensitiveTaxGroup}
 import uk.gov.hmrc.agentpermissions.models.GroupId
-import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, TaxGroup}
+import uk.gov.hmrc.agentpermissions.util.{Migrations, PlayMongoMigrations}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, PlainText}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
@@ -36,7 +37,7 @@ import javax.inject.{Inject, Named, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[TaxGroupsRepositoryV2Impl])
-trait TaxGroupsRepositoryV2 {
+trait TaxGroupsRepositoryV2 extends Migrations {
   def findById(id: GroupId): Future[Option[TaxGroup]]
   def get(arn: Arn): Future[Seq[TaxGroup]]
   def get(arn: Arn, groupName: String): Future[Option[TaxGroup]]
@@ -52,7 +53,7 @@ import uk.gov.hmrc.agentpermissions.repository.TaxGroupsRepositoryV2Impl.*
 
 @Singleton
 class TaxGroupsRepositoryV2Impl @Inject() (
-  mongoComponent: MongoComponent,
+  val mongoComponent: MongoComponent,
   @Named("aes") crypto: Encrypter & Decrypter
 )(using ec: ExecutionContext)
     extends PlayMongoRepository[SensitiveTaxGroup](
@@ -69,7 +70,7 @@ class TaxGroupsRepositoryV2Impl @Inject() (
             .collation(caseInsensitiveCollation)
         )
       )
-    ) with TaxGroupsRepositoryV2 with Logging {
+    ) with TaxGroupsRepositoryV2 with PlayMongoMigrations with Logging {
 
   // Ensure that we are using a deterministic cryptographic algorithm, or we won't be able to search on encrypted fields
   require(

--- a/app/uk/gov/hmrc/agentpermissions/service/KeyRotationService.scala
+++ b/app/uk/gov/hmrc/agentpermissions/service/KeyRotationService.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.service
+
+import com.google.inject.{Inject, Singleton}
+import play.api.Logging
+import uk.gov.hmrc.agentpermissions.config.AppConfig
+import uk.gov.hmrc.agentpermissions.repository.*
+import uk.gov.hmrc.mongo.lock.{LockRepository, LockService}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+@Singleton
+class KeyRotationService @Inject (
+  lockRepository: LockRepository,
+  appConfig: AppConfig,
+  optinRepository: OptinRepository,
+  customGroupsRepositoryV2: CustomGroupsRepositoryV2,
+  taxGroupsRepositoryV2: TaxGroupsRepositoryV2
+)(using ExecutionContext)
+    extends Logging:
+
+  private val lockService = LockService(
+    lockRepository,
+    lockId = "key-rotation-lock",
+    ttl = appConfig.keyRotation.maxTotalDuration
+  )
+
+  val migration: Future[Option[Unit]] =
+    if !appConfig.keyRotation.enabled then Future.successful(None)
+    else
+      val batchSize = appConfig.keyRotation.batchSize
+      val deadline = appConfig.keyRotation.maxTotalDuration.fromNow
+
+      logger.info("Starting key rotation migration")
+
+      lockService.withLock:
+        for
+          _ <- optinRepository.migrate(batchSize, deadline)
+          _ <- customGroupsRepositoryV2.migrate(batchSize, deadline)
+          _ <- taxGroupsRepositoryV2.migrate(batchSize, deadline)
+        yield ()
+
+  migration.onComplete:
+    case Failure(error)   => logger.error("Key rotation migration failed", error)
+    case Success(Some(_)) => logger.info("Key rotation migration completed successfully")
+    case Success(None)    => logger.warn("Key rotation migration disabled or did not acquire lock, skipping")

--- a/app/uk/gov/hmrc/agentpermissions/util/PlayMongoMigrations.scala
+++ b/app/uk/gov/hmrc/agentpermissions/util/PlayMongoMigrations.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.util
+
+import org.mongodb.scala.Document
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Filters.*
+import org.mongodb.scala.model.ReplaceOneModel
+import org.mongodb.scala.model.Sorts.ascending
+import play.api.Logging
+import uk.gov.hmrc.mongo.play.json.Codecs.DocumentOps
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import scala.concurrent.duration.{Deadline, Duration}
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+
+trait Migrations:
+  def migrate(batchSize: Int, deadline: Deadline): Future[Int]
+
+trait PlayMongoMigrations(using ExecutionContext) extends Migrations with Transactions:
+  self: PlayMongoRepository[?] & Logging =>
+
+  /** Runs a server-side migration in batches until all records are processed or the deadline is reached.
+    *
+    * The migration mechanism is the repository's current domain format: each stored record is read,
+    * decoded with the local model format, then written back. This allows schema evolution to be
+    * applied by the latest application codecs without a separate one-off mapping layer.
+    *
+    * Each batch runs in a transaction because records may be updated concurrently while migration is
+    * in progress. Transactional execution ensures each read/replace step is applied safely.
+    *
+    * If the deadline is exceeded, the migration fails with a timeout.
+    *
+    * @param batchSize
+    *   the maximum number of records to process per transaction
+    * @param deadline
+    *   the overall time budget for the migration
+    * @return
+    *   a future containing the total number of modified documents
+    */
+  def migrate(batchSize: Int, deadline: Deadline): Future[Int] =
+    given TransactionConfiguration = TransactionConfiguration.strict
+
+    def asUpdate(document: Document) =
+      val domainModel = document.fromBson(using self.domainFormat)
+      val isUnchanged = and(equal("_id", document("_id")))
+
+      ReplaceOneModel(filter = isUnchanged, replacement = domainModel)
+
+    def replaceBatch(cursor: Bson) =
+      withSessionAndTransaction: session =>
+        logger.info(s"transaction=${session.getServerSession.getTransactionNumber}}")
+        for
+          documents <- collection
+                         .find[Document](session, cursor)
+                         .sort(ascending("_id"))
+                         .limit(batchSize)
+                         .maxTime(deadline.timeLeft.max(Duration.Zero))
+                         .toFuture()
+
+          resultsOrNone <-
+            if documents.nonEmpty then collection.bulkWrite(session, documents.map(asUpdate)).headOption()
+            else Future.successful(None)
+
+        yield resultsOrNone.map: results =>
+          documents.last("_id") -> results.getModifiedCount
+
+    // Repeatedly execute the batch replacement, advancing the cursor to the last processed `_id`
+    // until there are no more matching documents to migrate.
+    def loop(cursor: Bson, totalModified: Int): Future[Int] =
+      if deadline.isOverdue then Future.failed(new TimeoutException("Key rotation migration exceeded maximum duration"))
+      else
+        replaceBatch(cursor)
+          .flatMap:
+            case Some(lastId -> modified) => loop(cursor = gt("_id", lastId), totalModified + modified)
+            case None                     => Future.successful(totalModified)
+
+    loop(cursor = Document.empty, totalModified = 0)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,6 +26,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 # Provides an instance of Crypto for field-level encryption
 play.modules.enabled += "uk.gov.hmrc.agentpermissions.CryptoProviderModule"
 
+play.modules.enabled += "uk.gov.hmrc.agentpermissions.MigrationsModule"
+
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
@@ -111,9 +113,15 @@ allowed.arns = []
 fieldLevelEncryption {
   enable = true
   key = "hWmZq3t6w9zrCeF5JiNcRfUjXn2r5u7x"
-  previousKeys = []
+  previousKeys = ["8BkW9VqK7uIQAL8ZHT6gXkjuTj5BFPw6c0MC2q2nQfg=", "eu2IgkfpOI9MYvoG1Q3eoFsWzyHO8fw/bwaSdS+21zg="]
 }
 
 eacdsync {
   notBeforeSeconds = 900
+}
+
+keyRotation {
+  enabled = false
+  maxTotalDuration = 10s
+  batchSize = 1
 }

--- a/it/test/uk/gov/hmrc/agentpermissions/BaseIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/agentpermissions/BaseIntegrationSpec.scala
@@ -27,8 +27,9 @@ import play.api.{Application, Configuration, Environment}
 abstract class BaseIntegrationSpec
     extends AnyWordSpec with Matchers with ScalaFutures with IntegrationPatience with GuiceOneServerPerSuite {
 
-  protected lazy val conf: Configuration = GuiceApplicationBuilder().configuration
-  protected lazy val env: Environment = GuiceApplicationBuilder().environment
+  private val applicationBuilder = GuiceApplicationBuilder()
+  protected lazy val conf: Configuration = applicationBuilder.configuration
+  protected lazy val env: Environment = applicationBuilder.environment
 
   /** Child classes can override per their requirements
     */

--- a/test/it/repository/AccessGroupsRepositoryISpec.scala
+++ b/test/it/repository/AccessGroupsRepositoryISpec.scala
@@ -19,21 +19,25 @@ package uk.gov.hmrc.agentpermissions.repository
 import org.apache.commons.lang3.RandomStringUtils.randomAlphabetic
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
+import org.mongodb.scala.gridfs.ObservableFuture
 import org.mongodb.scala.model.{Filters, IndexModel}
 import org.mongodb.scala.result.UpdateResult
+import org.scalatest.OptionValues
+import support.KeyRotationSupport
 import uk.gov.hmrc.agentpermissions.TestConstants
 import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, Client, CustomGroup}
 import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveAgentUser, SensitiveClient, SensitiveCustomGroup}
 import uk.gov.hmrc.agentpermissions.models.GroupId
-import org.mongodb.scala.gridfs.ObservableFuture
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositorySupport}
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Random
 
 class AccessGroupsRepositorySpec
-    extends TestConstants with PlayMongoRepositorySupport[SensitiveCustomGroup] with CleanMongoCollectionSupport {
+    extends TestConstants with PlayMongoRepositorySupport[SensitiveCustomGroup] with CleanMongoCollectionSupport
+    with OptionValues with KeyRotationSupport {
 
   given ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   val actorSystem: ActorSystem = ActorSystem()
@@ -333,8 +337,34 @@ class AccessGroupsRepositorySpec
         }
       }
     }
+
+    "encryption key migration" should {
+      "rotate the encryption key for records by reading them out and writing them back again" in new TestScope {
+        def generateRecord =
+          accessGroup.copy(
+            id = GroupId.random(),
+            arn = Arn(Random.alphanumeric.take(10).mkString)
+          )
+
+        val testData = Seq.fill(20)(generateRecord)
+        Future.traverse(testData)(accessGroupsRepository.insert).futureValue
+
+        // simulate a newly deployed encryption key
+        KeyRotationCrypto.rotateSecretKey(to = "eu2IgkfpOI9MYvoG1Q3eoFsWzyHO8fw/bwaSdS+21zg=", keepPreviousKey = true)
+
+        accessGroupsRepository.migrate(batchSize = 5, deadline = patienceConfig.timeout.fromNow).futureValue
+
+        // ensure all records were processed correctly
+        val results = accessGroupsRepository.collection.find().map(_.decryptedValue).toFuture().futureValue
+        results should contain theSameElementsAs testData
+
+        // the old encryption key can no longer decrypt the record
+        KeyRotationCrypto.rotateSecretKey(to = DefaultSecretKey)
+        accessGroupsRepository.collection.find().toFuture().failed.futureValue shouldBe a[SecurityException]
+      }
+    }
   }
 
   override protected val repository: PlayMongoRepository[SensitiveCustomGroup] =
-    new CustomGroupsRepositoryV2Impl(mongoComponent, aesCrypto)
+    new CustomGroupsRepositoryV2Impl(mongoComponent, KeyRotationCrypto)
 }

--- a/test/it/repository/EacdSyncRepositoryISpec.scala
+++ b/test/it/repository/EacdSyncRepositoryISpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.agentpermissions.repository
 
-import uk.gov.hmrc.agentpermissions.model.Arn
 import uk.gov.hmrc.agentpermissions.TestConstants
-import uk.gov.hmrc.agentpermissions.config.AppConfig
+import uk.gov.hmrc.agentpermissions.config.{AppConfig, KeyRotationConfig}
+import uk.gov.hmrc.agentpermissions.model.Arn
 import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.SingleObservableFuture
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositorySupport}
@@ -92,6 +92,8 @@ class EacdSyncRepositorySpec
     override def accessGroupChunkSize: Int = 100
     override def useEnrolmentAssignmentsChunkSize: Int = 100
     override def eacdSyncNotBeforeSeconds: Int = 10 // <- The value we care about in this test
+
+    override def keyRotation: KeyRotationConfig = ???
   }
 
 }

--- a/test/it/repository/OptinRepositoryISpec.scala
+++ b/test/it/repository/OptinRepositoryISpec.scala
@@ -16,26 +16,31 @@
 
 package uk.gov.hmrc.agentpermissions.repository
 
-import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.SingleObservableFuture
+import org.apache.pekko.actor.ActorSystem
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.mongodb.scala.model.IndexModel
-import uk.gov.hmrc.agentpermissions.model.Arn
+import org.scalatest.OptionValues
+import support.KeyRotationSupport
 import uk.gov.hmrc.agentpermissions.TestConstants
-import uk.gov.hmrc.agentpermissions.model.SensitiveOptinRecord
 import uk.gov.hmrc.agentpermissions.model.accessgroups.AgentUser
 import uk.gov.hmrc.agentpermissions.model.accessgroups.optin.*
 import uk.gov.hmrc.agentpermissions.model.accessgroups.optin.OptinEventType.*
+import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveOptinRecord}
 import uk.gov.hmrc.agentpermissions.repository.UpsertType.{RecordInserted, RecordUpdated}
+import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.{ObservableFuture, SingleObservableFuture}
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositorySupport}
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Random
 
 class OptinRepositorySpec
-    extends TestConstants with PlayMongoRepositorySupport[SensitiveOptinRecord] with CleanMongoCollectionSupport {
+    extends TestConstants with PlayMongoRepositorySupport[SensitiveOptinRecord] with CleanMongoCollectionSupport
+    with OptionValues with KeyRotationSupport {
 
   given ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  given ActorSystem = ActorSystem()
 
   trait TestScope {
     val arn: Arn = Arn("KARN1234567")
@@ -118,8 +123,33 @@ class OptinRepositorySpec
       }
     }
 
+    "encryption key migration" should {
+      "rotate the encryption key for records by reading them out and writing them back again" in new TestScope {
+        def generateRecord =
+          OptinRecord(
+            Arn(Random.alphanumeric.take(10).mkString),
+            List(OptinEvent(OptedIn, user, LocalDateTime.now()))
+          )
+
+        val testData = Seq.fill(20)(generateRecord)
+        Future.traverse(testData)(optinRepository.upsert).futureValue
+
+        // simulate a newly deployed encryption key
+        KeyRotationCrypto.rotateSecretKey(to = "eu2IgkfpOI9MYvoG1Q3eoFsWzyHO8fw/bwaSdS+21zg=", keepPreviousKey = true)
+
+        optinRepositoryImpl.migrate(batchSize = 5, deadline = patienceConfig.timeout.fromNow).futureValue
+
+        // ensure all records were processed correctly
+        val results = optinRepositoryImpl.collection.find().map(_.decryptedValue).toFuture().futureValue
+        results should contain theSameElementsAs testData
+
+        // the old encryption key can no longer decrypt the record
+        KeyRotationCrypto.rotateSecretKey(to = DefaultSecretKey)
+        optinRepositoryImpl.collection.find().toFuture().failed.futureValue shouldBe a[SecurityException]
+      }
+    }
   }
 
   override protected val repository: PlayMongoRepository[SensitiveOptinRecord] =
-    new OptinRepositoryImpl(mongoComponent, aesCrypto)
+    new OptinRepositoryImpl(mongoComponent, KeyRotationCrypto)
 }

--- a/test/it/repository/TaxServiceGroupsRepositoryISpec.scala
+++ b/test/it/repository/TaxServiceGroupsRepositoryISpec.scala
@@ -21,19 +21,23 @@ import org.apache.pekko.stream.Materializer
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.mongodb.scala.model.IndexModel
 import org.mongodb.scala.result.UpdateResult
+import org.scalatest.OptionValues
+import support.KeyRotationSupport
 import uk.gov.hmrc.agentpermissions.TestConstants
-import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveTaxGroup}
 import uk.gov.hmrc.agentpermissions.model.accessgroups.{AgentUser, Client, TaxGroup}
+import uk.gov.hmrc.agentpermissions.model.{Arn, SensitiveTaxGroup}
 import uk.gov.hmrc.agentpermissions.models.GroupId
-import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.SingleObservableFuture
+import uk.gov.hmrc.mongo.logging.ObservableFutureImplicits.{ObservableFuture, SingleObservableFuture}
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, PlayMongoRepositorySupport}
 
 import java.time.LocalDateTime
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Random
 
 class TaxServiceGroupsRepositorySpec
-    extends TestConstants with PlayMongoRepositorySupport[SensitiveTaxGroup] with CleanMongoCollectionSupport {
+    extends TestConstants with PlayMongoRepositorySupport[SensitiveTaxGroup] with CleanMongoCollectionSupport
+    with OptionValues with KeyRotationSupport {
 
   given ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   val actorSystem: ActorSystem = ActorSystem()
@@ -243,8 +247,35 @@ class TaxServiceGroupsRepositorySpec
         }
       }
     }
+
+    "encryption key migration" should {
+      "rotate the encryption key for records by reading them out and writing them back again" in new TestScope {
+        def generateRecord =
+          accessGroup.copy(
+            id = GroupId.random(),
+            arn = Arn(Random.alphanumeric.take(10).mkString)
+          )
+
+        val testData = Seq.fill(20)(generateRecord)
+        Future.traverse(testData)(groupsRepository.insert).futureValue
+
+        // simulate a newly deployed encryption key
+        KeyRotationCrypto.rotateSecretKey(to = "eu2IgkfpOI9MYvoG1Q3eoFsWzyHO8fw/bwaSdS+21zg=", keepPreviousKey = true)
+
+        val modified = groupsRepository.migrate(batchSize = 5, deadline = patienceConfig.timeout.fromNow).futureValue
+        modified shouldBe 20
+
+        // ensure all records were processed correctly
+        val results = groupsRepository.collection.find().map(_.decryptedValue).toFuture().futureValue
+        results should contain theSameElementsAs testData
+
+        // the old encryption key can no longer decrypt the record
+        KeyRotationCrypto.rotateSecretKey(to = DefaultSecretKey)
+        groupsRepository.collection.find().toFuture().failed.futureValue shouldBe a[SecurityException]
+      }
+    }
   }
 
   override protected val repository: PlayMongoRepository[SensitiveTaxGroup] =
-    new TaxGroupsRepositoryV2Impl(mongoComponent, aesCrypto)
+    new TaxGroupsRepositoryV2Impl(mongoComponent, KeyRotationCrypto)
 }

--- a/test/support/KeyRotationSupport.scala
+++ b/test/support/KeyRotationSupport.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support
+
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainBytes, PlainContent, PlainText, SymmetricCryptoFactory}
+
+/** Provides the ability to change the current encryption key for a given repository.
+  *
+  * Creating multiple repositories in order to change the key can cause race conditions and other issues around the
+  * Mongo collection initialisation. It's much more lightweight to have a single repository and change the key on
+  * demand. This trait provides a simple way to achieve that in tests. You can also change the key multiple times
+  * without having to instantiate a new repository each time.
+  */
+trait KeyRotationSupport extends BeforeAndAfterEach:
+  this: Suite =>
+
+  val DefaultSecretKey = "HV6NcLoiRka1OjZmYRtleBa9gxxZeyadSjoHDN1fi+4="
+
+  object KeyRotationCrypto extends Encrypter with Decrypter:
+    @volatile private var ref: Encrypter & Decrypter = SymmetricCryptoFactory.aesCrypto(DefaultSecretKey)
+
+    def rotateSecretKey(to: String, keepPreviousKey: Boolean = false): Unit =
+      val aes = SymmetricCryptoFactory.aesCrypto(to)
+      val prev = ref // capture ref before overwriting it
+      ref = if !keepPreviousKey then aes else SymmetricCryptoFactory.composeCrypto(aes, Seq(prev))
+
+    override def encrypt(plain: PlainContent): Crypted = ref.encrypt(plain)
+    override def decrypt(reversiblyEncrypted: Crypted): PlainText = ref.decrypt(reversiblyEncrypted)
+    override def decryptAsBytes(reversiblyEncrypted: Crypted): PlainBytes = ref.decryptAsBytes(reversiblyEncrypted)
+
+  override protected def beforeEach(): Unit =
+    super.beforeEach()
+    KeyRotationCrypto.rotateSecretKey(to = DefaultSecretKey)

--- a/test/support/TestConstants.scala
+++ b/test/support/TestConstants.scala
@@ -91,4 +91,5 @@ trait TestConstants extends AnyWordSpecLike with Matchers with ScalaFutures with
   // Note: This is simply a randomly-chosen secret key to run tests
   val aesCrypto: Encrypter & Decrypter =
     SymmetricCryptoFactory.aesCrypto(secretKey = "hWmZq3t6w9zrCeF5JiNcRfUjXn2r5u7x")
+
 }

--- a/test/uk/gov/hmrc/agentpermissions/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/config/AppConfigSpec.scala
@@ -49,4 +49,16 @@ class AppConfigSpec extends UnitSpec {
       testAppConfig.teamMembersRemovalChunkSize shouldBe 200
     }
   }
+
+  "read key rotation config correctly" in {
+    val testAppConfig =
+      new AppConfigImpl(
+        new ServicesConfig(configuration),
+        configuration
+      )
+
+    testAppConfig.keyRotation.enabled shouldBe false
+    testAppConfig.keyRotation.maxTotalDuration.toSeconds shouldBe 10
+    testAppConfig.keyRotation.batchSize shouldBe 1
+  }
 }

--- a/test/uk/gov/hmrc/agentpermissions/service/KeyRotationServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentpermissions/service/KeyRotationServiceSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentpermissions.service
+
+import uk.gov.hmrc.agentpermissions.TestConstants
+import uk.gov.hmrc.agentpermissions.config.{AppConfig, KeyRotationConfig}
+import uk.gov.hmrc.agentpermissions.repository.{CustomGroupsRepositoryV2, OptinRepository, TaxGroupsRepositoryV2}
+import uk.gov.hmrc.mongo.lock.{Lock, LockRepository}
+
+import java.time.Instant
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+
+class KeyRotationServiceSpec extends TestConstants:
+
+  trait TestScope:
+    given ExecutionContext = ExecutionContext.Implicits.global
+
+    val lockRepository: LockRepository = mock[LockRepository]
+
+    val appConfig: AppConfig = mock[AppConfig]
+
+    val optinRepository: OptinRepository = stub[OptinRepository]
+    val customGroupsRepository: CustomGroupsRepositoryV2 = stub[CustomGroupsRepositoryV2]
+    val taxGroupsRepository: TaxGroupsRepositoryV2 = stub[TaxGroupsRepositoryV2]
+
+    val keyRotationConfig: KeyRotationConfig = KeyRotationConfig(
+      enabled = true,
+      maxTotalDuration = 10.seconds,
+      batchSize = 1
+    )
+
+    lazy val keyRotationService = new KeyRotationService(
+      lockRepository,
+      appConfig,
+      optinRepository,
+      customGroupsRepository,
+      taxGroupsRepository
+    )
+
+  "KeyRotationService" when:
+
+    "key rotation is disabled" should:
+      "skip migration and complete without running repository migrations" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig.copy(enabled = false)).anyNumberOfTimes()
+        lockRepository.takeLock.expects(*, *, *).never()
+        lockRepository.releaseLock.expects(*, *).never()
+
+        noException should be thrownBy:
+          keyRotationService.migration.futureValue
+
+        optinRepository.migrate.verify(*, *).never()
+        customGroupsRepository.migrate.verify(*, *).never()
+        taxGroupsRepository.migrate.verify(*, *).never()
+
+    "key rotation is enabled" should:
+      "run migrations for optin, custom groups, and tax groups when lock is acquired" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig).anyNumberOfTimes()
+        lockRepository.takeLock
+          .expects(*, *, *)
+          .returning(Future.successful(Some(Lock("", "", Instant.now(), Instant.MAX))))
+        lockRepository.releaseLock
+          .expects(*, *)
+          .returning(Future.unit)
+        optinRepository.migrate.when(*, *).returns(Future.successful(100))
+        customGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+        taxGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+
+        keyRotationService.migration.futureValue
+
+        optinRepository.migrate.verify(*, *).once()
+        customGroupsRepository.migrate.verify(*, *).once()
+        taxGroupsRepository.migrate.verify(*, *).once()
+
+      "skip migration when lock is not acquired" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig).anyNumberOfTimes()
+        lockRepository.takeLock.expects(*, *, *).returning(Future.successful(None))
+        lockRepository.releaseLock.expects(*, *).never()
+
+        noException should be thrownBy:
+          keyRotationService.migration.futureValue
+
+        optinRepository.migrate.verify(*, *).never()
+        customGroupsRepository.migrate.verify(*, *).never()
+        taxGroupsRepository.migrate.verify(*, *).never()
+
+      "stop and fail when optin migration fails" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig).anyNumberOfTimes()
+        lockRepository.takeLock
+          .expects(*, *, *)
+          .returning(Future.successful(Some(Lock("", "", Instant.now(), Instant.MAX))))
+        lockRepository.releaseLock.expects(*, *).returning(Future.unit)
+        optinRepository.migrate.when(*, *).returns(Future.failed(RuntimeException("optin migration failed")))
+        customGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+        taxGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+
+        keyRotationService.migration.failed.futureValue
+
+        customGroupsRepository.migrate.verify(*, *).never()
+        taxGroupsRepository.migrate.verify(*, *).never()
+
+      "stop and fail when custom groups migration fails" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig).anyNumberOfTimes()
+        lockRepository.takeLock
+          .expects(*, *, *)
+          .returning(Future.successful(Some(Lock("", "", Instant.now(), Instant.MAX))))
+        lockRepository.releaseLock.expects(*, *).returning(Future.unit)
+        optinRepository.migrate.when(*, *).returns(Future.successful(100))
+        customGroupsRepository.migrate
+          .when(*, *)
+          .returns(Future.failed(RuntimeException("custom groups migration failed")))
+        taxGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+
+        keyRotationService.migration.failed.futureValue
+
+        optinRepository.migrate.verify(*, *).once()
+        taxGroupsRepository.migrate.verify(*, *).never()
+
+      "stop and fail when tax groups migration fails" in new TestScope:
+        (() => appConfig.keyRotation).expects().returning(keyRotationConfig).anyNumberOfTimes()
+        lockRepository.takeLock
+          .expects(*, *, *)
+          .returning(Future.successful(Some(Lock("", "", Instant.now(), Instant.MAX))))
+        lockRepository.releaseLock.expects(*, *).returning(Future.unit)
+        optinRepository.migrate.when(*, *).returns(Future.successful(100))
+        customGroupsRepository.migrate.when(*, *).returns(Future.successful(100))
+        taxGroupsRepository.migrate.when(*, *).returns(Future.failed(RuntimeException("tax groups migration failed")))
+
+        keyRotationService.migration.failed.futureValue
+
+        optinRepository.migrate.verify(*, *).once()
+        customGroupsRepository.migrate.verify(*, *).once()


### PR DESCRIPTION
Implements a key rotation mechanism for rolling out new encryption keys to existing encrypted data. It takes the form of a migration stream triggered via an endpoint.

**Implementation**

* Iterates each object ID in the target collection. The service performs encryption server-side, so it needs to fully deserialise and serialise the document back to the database.
* It processes documents in batches to avoid storing the entire collection in memory, as well as opening a fresh transaction per group to avoid accidentally overwriting updates during re-encryption.
* The endpoint streams updates back to the caller, which can abandon the process at any time if needed (for example, the migration causes the database to struggle or another urgent production issue arises).

**Testing**

Tested locally against generated data and confirmed the re-encryption takes place as expected.

**Documentation**

Once I've tested the full flow (including secrets redeployment) I'll come back and add some documentation on how to run the migrations.